### PR TITLE
Do not refresh on exiting immersive mode

### DIFF
--- a/document-viewer/src/main/java/org/emdev/ui/uimanager/UIManager44x.java
+++ b/document-viewer/src/main/java/org/emdev/ui/uimanager/UIManager44x.java
@@ -2,11 +2,10 @@ package org.emdev.ui.uimanager;
 
 import static android.view.View.SYSTEM_UI_FLAG_FULLSCREEN;
 import static android.view.View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
+import static android.view.View.SYSTEM_UI_FLAG_IMMERSIVE;
 import static android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
 import static android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
-import static android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
 import static android.view.View.SYSTEM_UI_FLAG_LOW_PROFILE;
-import static android.view.View.SYSTEM_UI_FLAG_IMMERSIVE;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -19,6 +18,10 @@ public class UIManager44x extends UIManager40x {
     SYSTEM_UI_FLAG_LOW_PROFILE |
     /**/
     SYSTEM_UI_FLAG_FULLSCREEN |
+    /**/
+    SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+    /**/
+    SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
     /**/
     SYSTEM_UI_FLAG_HIDE_NAVIGATION |
     /**/


### PR DESCRIPTION
I didn't put it due this bug with action bar:
![screenshot](https://f.cloud.github.com/assets/833473/2180130/1cbd6a94-96fb-11e3-80f1-a6e1d43b2e50.png)
(on show title bar mode, a bit of action bar will shifted to down due some bug)
But this totally worth to remove the annoying delay on refresh PDF pages every time you want bring android System UI or app switch and even not apparent when title bar is hide by preference (that I think most users would do that). This is my fault that I didn't it from the beginning and I am sorry. EbookDroid totally rewrote the menu bar seems due such bugs.
