### PR TITLE
Split apk for each ABIs (and upgrade SDK to v22)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.2'
+        classpath 'com.android.tools.build:gradle:1.2.2'
     }
 }
 

--- a/document-viewer/build.gradle
+++ b/document-viewer/build.gradle
@@ -14,6 +14,19 @@ android {
         targetSdkVersion 22
     }
 
+    sourceSets.main {
+        jniLibs.srcDir 'libs'
+    }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips', 'mips64', 'x86', 'x86_64'
+            universalApk false
+        }
+    }
+
     /*
      * To sign release build, create file gradle.properties in ~/.gradle/ with this content:
      *
@@ -48,11 +61,3 @@ android {
     }
 }
 
-/**
- * Android Gradle Plugin 0.7 does not support library packaging.
- * This is a hack from https://groups.google.com/d/msg/adt-dev/Dkf9nsZlq8I/3gtG1Ofu1zAJ
- */
-tasks.withType(com.android.build.gradle.tasks.PackageApplication) { pkgTask ->
-    pkgTask.jniFolders = new HashSet<File>()
-    pkgTask.jniFolders.add(new File(projectDir, 'libs'))
-}

--- a/document-viewer/build.gradle
+++ b/document-viewer/build.gradle
@@ -2,16 +2,16 @@ apply plugin: 'com.android.application'
 
 dependencies {
     compile fileTree(dir: 'libs', includes: ['jcifs-1.3.17.jar'])
-    compile 'com.android.support:support-v4:19.0.1'
+    compile 'com.android.support:support-v4:22.1.0'
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 22
     }
 
     /*


### PR DESCRIPTION
This PR introduces splitting apk for each ABIs (which is suggessted in #88).

This needs newer SDK than v19 (I guess),
so I upgraded SDK and Gradle plugin as well.

It seems to me like upgrading SDK alone makes no bad side effects to UI (which is mentioned in #92).
