### PR TITLE
Support FZ_LINK_URI links in pdf documents.

### DIFF
--- a/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
+++ b/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
@@ -431,7 +431,7 @@ JNI_FN(MuPdfLinks_fillPageLinkSourceRect)(JNIEnv *env, jclass clazz, jlong linkh
 {
     fz_link *link = (fz_link*) (long) linkhandle;
 
-    if (!link || link->dest.kind != FZ_LINK_GOTO)
+    if (!link)
     {
         return JNI_FALSE;
     }

--- a/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
@@ -20,9 +20,12 @@ import org.ebookdroid.ui.viewer.IActivityController;
 import org.ebookdroid.ui.viewer.IView;
 import org.ebookdroid.ui.viewer.IViewController;
 
+import android.content.Context;
+import android.content.Intent;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.net.Uri;
 import android.util.FloatMath;
 import android.view.GestureDetector.SimpleOnGestureListener;
 import android.view.KeyEvent;
@@ -581,8 +584,22 @@ public abstract class AbstractViewController extends AbstractComponentController
             LCTX.d("Page link found under tap: " + link);
         }
 
+        if (link.url != null) {
+            goToURL(link.url);
+            return true;
+        }
+
         goToLink(link.targetPage, link.targetRect, AppSettings.current().storeLinkGotoHistory);
         return true;
+    }
+
+    private void goToURL(String url) {
+        Context ctx = base.getContext();
+        Uri parsed = Uri.parse(url);
+        Intent intent = new Intent(Intent.ACTION_VIEW, parsed);
+        if (intent.resolveActivity(ctx.getPackageManager()) != null) {
+            ctx.startActivity(intent);
+        }
     }
 
     /**

--- a/document-viewer/src/main/java/org/ebookdroid/droids/mupdf/codec/MuPdfLinks.java
+++ b/document-viewer/src/main/java/org/ebookdroid/droids/mupdf/codec/MuPdfLinks.java
@@ -23,19 +23,20 @@ public class MuPdfLinks {
         for (long linkHandle = getFirstPageLink(docHandle, pageHandle); linkHandle != 0; linkHandle = getNextPageLink(linkHandle)) {
             final PageLink link = new PageLink();
             final int type = getPageLinkType(linkHandle);
+
+            link.rectType = 1;
+            if (fillPageLinkSourceRect(linkHandle, temp)) {
+                link.sourceRect = new RectF();
+                link.sourceRect.left = (temp[0] - pageBounds.left) / pageBounds.width();
+                link.sourceRect.top = (temp[1] - pageBounds.top) / pageBounds.height();
+                link.sourceRect.right = (temp[2] - pageBounds.left) / pageBounds.width();
+                link.sourceRect.bottom = (temp[3] - pageBounds.top) / pageBounds.height();
+            }
+
             if (type == FZ_LINK_URI) {
                 link.url = getPageLinkUrl(linkHandle);
                 links.add(link);
             } else if (type == FZ_LINK_GOTO) {
-                link.rectType = 1;
-                if (fillPageLinkSourceRect(linkHandle, temp)) {
-                    link.sourceRect = new RectF();
-                    link.sourceRect.left = (temp[0] - pageBounds.left) / pageBounds.width();
-                    link.sourceRect.top = (temp[1] - pageBounds.top) / pageBounds.height();
-                    link.sourceRect.right = (temp[2] - pageBounds.left) / pageBounds.width();
-                    link.sourceRect.bottom = (temp[3] - pageBounds.top) / pageBounds.height();
-                }
-
                 link.targetPage = getPageLinkTargetPage(linkHandle);
                 if (link.targetPage > 0) {
                     int flags = fillPageLinkTargetPoint(linkHandle, temp);


### PR DESCRIPTION
* Modify MuPdfLinks.fillPageLinkSourceRect() to fill in the link rect for any link type, not just FZ_LINK_GOTO
* Check link.url in AbstractViewController.processLinkTap(), added a goToUrl method to open the URL.
* In MuPdfLinks.getPageLinks(), always set link.rectType and link.sourceRect

With these changes, URL hyperlinks in PDF documents are highlighted in yellow and open in the browser when tapped.