### PR TITLE
Ignore taps that stop scrolling

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
@@ -625,6 +625,8 @@ public abstract class AbstractViewController extends AbstractComponentController
 
         protected final LogContext LCTX = LogManager.root().lctx("Gesture", false);
 
+        private boolean ignoreNextTap;
+
         /**
          * {@inheritDoc}
          *
@@ -645,7 +647,12 @@ public abstract class AbstractViewController extends AbstractComponentController
          */
         @Override
         public boolean onDown(final MotionEvent e) {
-            getView().forceFinishScroll();
+            if (getView().forceFinishScroll()) {
+                // this touch down caused scrolling to finish, so ignore the next onSingleTapConfirmed()
+                ignoreNextTap = true;
+            } else {
+                ignoreNextTap = false;
+            }
             if (LCTX.isDebugEnabled()) {
                 LCTX.d("onDown(" + e + ")");
             }
@@ -720,6 +727,10 @@ public abstract class AbstractViewController extends AbstractComponentController
         public boolean onSingleTapConfirmed(final MotionEvent e) {
             if (LCTX.isDebugEnabled()) {
                 LCTX.d("onSingleTapConfirmed(" + e + ")");
+            }
+            if (ignoreNextTap) {
+                ignoreNextTap = false;
+                return false;
             }
             return processTap(TouchManager.Touch.SingleTap, e);
         }

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/IView.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/IView.java
@@ -28,7 +28,12 @@ public interface IView {
 
     void continueScroll();
 
-    void forceFinishScroll();
+    /**
+     * Forces the scrolling to finish
+     *
+     * @return true if this call forced the scrolling to finish, false if it was already finished
+     */
+    boolean forceFinishScroll();
 
     void scrollBy(int x, int y);
 

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/stubs/ViewStub.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/stubs/ViewStub.java
@@ -44,7 +44,8 @@ public class ViewStub implements IView {
     }
 
     @Override
-    public void forceFinishScroll() {
+    public boolean forceFinishScroll() {
+        return false;
     }
 
     @Override

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/viewers/GLView.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/viewers/GLView.java
@@ -162,8 +162,10 @@ public final class GLView extends GLRootView implements IView, SurfaceHolder.Cal
      * @see org.ebookdroid.ui.viewer.IView#forceFinishScroll()
      */
     @Override
-    public void forceFinishScroll() {
+    public boolean forceFinishScroll() {
+        boolean wasFinished = scroller.isFinished();
         scroller.forceFinished(); // to stop flinging on touch
+        return !wasFinished;
     }
 
     /**


### PR DESCRIPTION
If you do a "fling" to scroll quickly, and then tap to stop scrolling, currently that tap will also be handled as its own action (e.g. if you tap a link, or in the bottom of the screen to trigger a flip to the next page, those events will happen.)

With this PR, a tap that stops a fling won't do anything else.

Normally this wouldn't be a very noticeable change, since tapping on the middle of a page doesn't do anything by default. However, if you configure a tap in the middle of the screen to toggle fullscreen, it's quite annoying when a tap to stop a fling also toggles fullscreen.