### PR TITLE
Replace uses of FloatMath class with Math

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/common/bitmaps/GLBitmaps.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/bitmaps/GLBitmaps.java
@@ -69,7 +69,7 @@ public class GLBitmaps {
         if (size % partSize == 0) {
             return size / partSize;
         }
-        return (int) FloatMath.ceil(size / (float) partSize);
+        return (int) Math.ceil(size / (float) partSize);
     }
 
     public boolean drawGL(final GLCanvas canvas, final PagePaint paint, final PointF vb, final RectF tr, final RectF cr) {

--- a/document-viewer/src/main/java/org/ebookdroid/common/touch/MultiTouchGestureDetector.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/touch/MultiTouchGestureDetector.java
@@ -131,7 +131,7 @@ public class MultiTouchGestureDetector implements IGestureDetector {
     }
 
     private float distance(final PointF p0, final PointF p1) {
-        return FloatMath.sqrt(((p0.x - p1.x) * (p0.x - p1.x) + (p0.y - p1.y) * (p0.y - p1.y)));
+        return (float) Math.sqrt(((p0.x - p1.x) * (p0.x - p1.x) + (p0.y - p1.y) * (p0.y - p1.y)));
     }
 
     private PointF calculateCenter(final MotionEvent ev) {
@@ -156,6 +156,6 @@ public class MultiTouchGestureDetector implements IGestureDetector {
         final float x1 = ev.getX(1);
         final float y0 = ev.getY(0);
         final float y1 = ev.getY(1);
-        return FloatMath.sqrt(((x0 - x1) * (x0 - x1) + (y0 - y1) * (y0 - y1)));
+        return (float) Math.sqrt(((x0 - x1) * (x0 - x1) + (y0 - y1) * (y0 - y1)));
     }
 }

--- a/document-viewer/src/main/java/org/ebookdroid/common/touch/TouchManagerView.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/touch/TouchManagerView.java
@@ -214,10 +214,10 @@ public class TouchManagerView extends View {
         float top = MathUtils.fmin(startPoint.y, endPoint.y);
         float bottom = MathUtils.fmax(startPoint.y, endPoint.y);
 
-        left = cellWidth * FloatMath.floor(left / xStep);
-        right = cellWidth * FloatMath.floor(right / xStep) + cellWidth;
-        top = cellHeight * FloatMath.floor(top / yStep);
-        bottom = cellHeight * FloatMath.floor(bottom / yStep) + cellHeight;
+        left = cellWidth * (float) Math.floor(left / xStep);
+        right = cellWidth * (float) Math.floor(right / xStep) + cellWidth;
+        top = cellHeight * (float) Math.floor(top / yStep);
+        bottom = cellHeight * (float) Math.floor(bottom / yStep) + cellHeight;
 
         return new Region(MathUtils.rect(left, top, right, bottom));
     }

--- a/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
@@ -756,7 +756,7 @@ public abstract class AbstractViewController extends AbstractComponentController
          */
         @Override
         public void onTwoFingerPinch(final MotionEvent e, final float oldDistance, final float newDistance) {
-            final float factor = FloatMath.sqrt(newDistance / oldDistance);
+            final float factor = (float) Math.sqrt(newDistance / oldDistance);
             if (LCTX.isDebugEnabled()) {
                 LCTX.d("onTwoFingerPinch(" + oldDistance + ", " + newDistance + "): " + factor);
             }

--- a/document-viewer/src/main/java/org/ebookdroid/core/Page.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/Page.java
@@ -66,7 +66,7 @@ public class Page {
     }
 
     private boolean setAspectRatio(final float aspectRatio) {
-        final int newAspectRatio = (int) FloatMath.floor(aspectRatio * 128);
+        final int newAspectRatio = (int) Math.floor(aspectRatio * 128);
         if (this.aspectRatio != newAspectRatio) {
             this.aspectRatio = newAspectRatio;
             return true;

--- a/document-viewer/src/main/java/org/ebookdroid/core/curl/Vector2D.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/curl/Vector2D.java
@@ -66,7 +66,7 @@ public class Vector2D extends PointF {
     }
 
     public float distance(final Vector2D other) {
-        return FloatMath.sqrt(distanceSquared(other));
+        return (float) Math.sqrt(distanceSquared(other));
     }
 
     public float absdistancex(final Vector2D other) {
@@ -82,7 +82,7 @@ public class Vector2D extends PointF {
     }
 
     public Vector2D normalize() {
-        final float magnitude = FloatMath.sqrt(dotProduct(this));
+        final float magnitude = (float) Math.sqrt(dotProduct(this));
         return new Vector2D(x / magnitude, y / magnitude);
     }
 

--- a/document-viewer/src/main/java/org/emdev/common/textmarkup/TextStyle.java
+++ b/document-viewer/src/main/java/org/emdev/common/textmarkup/TextStyle.java
@@ -44,6 +44,6 @@ public enum TextStyle {
 
     public int getFontSize() {
         final FontSize fs = AppSettings.current().fontSize;
-        return (int) FloatMath.ceil(TEXT_SIZE * fs.factor * this.factor);
+        return (int) Math.ceil(TEXT_SIZE * fs.factor * this.factor);
     }
 }

--- a/document-viewer/src/main/java/org/emdev/ui/gl/StringTexture.java
+++ b/document-viewer/src/main/java/org/emdev/ui/gl/StringTexture.java
@@ -49,12 +49,12 @@ public class StringTexture extends CanvasTexture {
         mPaint = paint;
         mMetrics = paint.getFontMetricsInt();
         mText = text;
-        mTextWidth = (int) FloatMath.ceil(mPaint.measureText(mText));
+        mTextWidth = (int) Math.ceil(mPaint.measureText(mText));
         mTextHeight = mMetrics.bottom - mMetrics.top;
 
         if (mTextWidth > mCanvasWidth) {
             mText = TextUtils.ellipsize(mText, mPaint, mCanvasWidth, TextUtils.TruncateAt.END).toString();
-            mTextWidth = (int) FloatMath.ceil(mPaint.measureText(mText));
+            mTextWidth = (int) Math.ceil(mPaint.measureText(mText));
         }
         if (!CompareUtils.equals(mText, oldText) || mTextHeight != oldTextHeight) {
             if (mBitmap != null) {

--- a/document-viewer/src/main/java/org/emdev/utils/MathUtils.java
+++ b/document-viewer/src/main/java/org/emdev/utils/MathUtils.java
@@ -74,38 +74,38 @@ public class MathUtils {
     }
 
     public static float round(final float value, final float share) {
-        return FloatMath.floor(value * share) / share;
+        return (float) Math.floor(value * share) / share;
     }
 
     public static RectF round(final RectF rect, final float share) {
-        rect.left = FloatMath.floor(rect.left * share) / share;
-        rect.top = FloatMath.floor(rect.top * share) / share;
-        rect.right = FloatMath.floor(rect.right * share) / share;
-        rect.bottom = FloatMath.floor(rect.bottom * share) / share;
+        rect.left = (float) Math.floor(rect.left * share) / share;
+        rect.top = (float) Math.floor(rect.top * share) / share;
+        rect.right = (float) Math.floor(rect.right * share) / share;
+        rect.bottom = (float) Math.floor(rect.bottom * share) / share;
         return rect;
     }
 
     public static RectF floor(final RectF rect) {
-        rect.left = FloatMath.floor(rect.left);
-        rect.top = FloatMath.floor(rect.top);
-        rect.right = FloatMath.floor(rect.right);
-        rect.bottom = FloatMath.floor(rect.bottom);
+        rect.left = (float) Math.floor(rect.left);
+        rect.top = (float) Math.floor(rect.top);
+        rect.right = (float) Math.floor(rect.right);
+        rect.bottom = (float) Math.floor(rect.bottom);
         return rect;
     }
 
     public static RectF ceil(final RectF rect) {
-        rect.left = FloatMath.ceil(rect.left);
-        rect.top = FloatMath.ceil(rect.top);
-        rect.right = FloatMath.ceil(rect.right);
-        rect.bottom = FloatMath.ceil(rect.bottom);
+        rect.left = (float) Math.ceil(rect.left);
+        rect.top = (float) Math.ceil(rect.top);
+        rect.right = (float) Math.ceil(rect.right);
+        rect.bottom = (float) Math.ceil(rect.bottom);
         return rect;
     }
 
     public static RectF round(final RectF rect) {
-        rect.left = FloatMath.floor(rect.left);
-        rect.top = FloatMath.floor(rect.top);
-        rect.right = FloatMath.ceil(rect.right);
-        rect.bottom = FloatMath.ceil(rect.bottom);
+        rect.left = (float) Math.floor(rect.left);
+        rect.top = (float) Math.floor(rect.top);
+        rect.right = (float) Math.ceil(rect.right);
+        rect.bottom = (float) Math.ceil(rect.bottom);
         return rect;
     }
 


### PR DESCRIPTION
FloatMath was deprecated in API 22, and removed in API 23.

This is a prerequisite for upgrading the target SDK version to 23.