### PR TITLE
Fix for volume UI appearing when scrolling with volume buttons

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/AbstractViewController.java
@@ -365,14 +365,21 @@ public abstract class AbstractViewController extends AbstractComponentController
 	    return false;
 	}
 
-        if (event.getAction() == KeyEvent.ACTION_UP) {
+        if (event.getAction() == KeyEvent.ACTION_UP
+                || event.getAction() == KeyEvent.ACTION_DOWN) {
             final Integer actionId = KeyBindingsManager.getAction(event);
             final ActionEx action = actionId != null ? getOrCreateAction(actionId) : null;
             if (action != null) {
                 if (LCTX.isDebugEnabled()) {
                     LCTX.d("Key action: " + action.name + ", " + action.getMethod().toString());
                 }
-                action.run();
+                // Only run the action on KeyEvent.ACTION_UP, but return true to consume the event
+                // on ACTION_DOWN or ACTION_UP.
+                // This prevents the system volume control UI from appearing on the ACTION_DOWN
+                // of a volume button.
+                if (event.getAction() == KeyEvent.ACTION_UP) {
+                    action.run();
+                }
                 return true;
             } else {
                 if (LCTX.isDebugEnabled()) {


### PR DESCRIPTION
AbstractViewController.dispatchKeyEvent(): If a key is bound, consume both key down and key up events.

Previously, this code was only consuming the key up events.
This fixes https://github.com/SufficientlySecure/document-viewer/issues/128  (tested on my Nexus 4 running Android 5.1.1); now the system volume control UI no longer appears when I use the volume buttons to flip pages.

TODO: For the scroll up/down keybindings, it would be better if the scrolling continued as long as you held the buttons down, instead of just scrolling once upon releasing the button.