### PR TITLE
Use material theme on Android 5.0+

### DIFF
--- a/document-viewer/src/main/res/values-v21/service_styles.xml
+++ b/document-viewer/src/main/res/values-v21/service_styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ebookdroid"
+           parent="android:Theme.Material">
+    </style>
+
+</resources>


### PR DESCRIPTION
Small change to use the Material theme on Android 5.0+.

I didn't bother copying using ebookdroid.ActionBarStyle in the new theme, because all that seemed to be doing was setting the foreground and background colors to @color/actionbar_white and @color/actionbar_black

We could customize the status bar / action bar colours, see: http://developer.android.com/training/material/theme.html , but I'm not sure what they should be so I just left it alone. This gives a black status bar and dark grey action bar.

With the material theme, the progress spinner when a page is loading is gone now, and the Action Bar icon is gone as well.

Here are some screenshots:
![screen1](https://cloud.githubusercontent.com/assets/239161/11009301/2af10d78-8493-11e5-8e82-c8ab8884c9a7.png)
![screen2](https://cloud.githubusercontent.com/assets/239161/11009305/2fa817c6-8493-11e5-8c9c-3c53af7b9140.png)
![screen3](https://cloud.githubusercontent.com/assets/239161/11009308/31424eda-8493-11e5-8294-9019c168975c.png)