### PR TITLE
Add an Up button to the viewer activity actionbar

### DIFF
--- a/document-viewer/src/main/AndroidManifest.xml
+++ b/document-viewer/src/main/AndroidManifest.xml
@@ -29,7 +29,13 @@
         <meta-data android:name="com.sec.android.support.multiwindow" android:value="true"/>
         <activity
             android:name="org.ebookdroid.ui.viewer.ViewerActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize">
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:parentActivityName="org.ebookdroid.ui.library.RecentActivity">
+
+            <!-- Parent activity metadata for API below 16 -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.ebookdroid.ui.library.RecentActivity" />
 
             <!-- 
                 Note: Intent matching isn't as easy as it looks at first sight.

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivity.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivity.java
@@ -128,6 +128,10 @@ public class ViewerActivity extends AbstractActionActivity<ViewerActivity, Viewe
         }
 
         setContentView(frameLayout);
+
+        if (!AndroidVersion.lessThan3x) {
+            getActionBar().setDisplayHomeAsUpEnabled(true);
+        }
     }
 
     /**

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -41,6 +41,7 @@ import org.ebookdroid.ui.viewer.views.ManualCropView;
 import org.ebookdroid.ui.viewer.views.SearchControls;
 import org.ebookdroid.ui.viewer.views.ViewEffects;
 
+import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
@@ -49,6 +50,8 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.app.NavUtils;
+import android.support.v4.app.TaskStackBuilder;
 import android.text.Editable;
 import android.text.InputType;
 import android.view.KeyEvent;
@@ -783,6 +786,23 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
         builder.setPositiveButton(R.string.confirmsave_yes_btn, R.id.actions_showSaveDlg);
         builder.setNegativeButton(R.string.confirmsave_no_btn, R.id.actions_doClose);
         builder.show();
+    }
+
+    @ActionMethod(ids = android.R.id.home)
+    public void navigateUp(final ActionEx action) {
+        // Standard implementation of the up button from http://developer.android.com/training/implementing-navigation/ancestral.html
+        Activity activity = getActivity();
+        Intent upIntent = NavUtils.getParentActivityIntent(activity);
+        if (NavUtils.shouldUpRecreateTask(activity, upIntent)) {
+            // e.g., this is the case when opening a pdf from the Downloads app and pressing the up button:
+            // the ViewerActivity is running in the Downloads task, so the following will start a new task
+            // to open the document-viewer library in.
+            TaskStackBuilder.create(activity)
+                    .addNextIntentWithParentStack(upIntent)
+                    .startActivities();
+        } else {
+            NavUtils.navigateUpTo(activity, upIntent);
+        }
     }
 
     @ActionMethod(ids = R.id.actions_showSaveDlg)


### PR DESCRIPTION
..to go back to the library activity (which is org.ebookdroid.ui.library.RecentActivity).

Implemented as described in this guide: http://developer.android.com/training/implementing-navigation/ancestral.html

- One thing I didn't handle is showing the "Save?" dialog like the "Close" menu action does: it's awkward to implement, and showing a confirmation dialog like that when navigating away from an activity is a UI anti-pattern, I think. (Related: https://github.com/SufficientlySecure/document-viewer/issues/64 ). However, this makes the "Up" button behaviour inconsistent with the "Close" menu item, so maybe I should implement the save confirmation dialog for the up button anyway.

Screenshot: (it also looks good with my Material theme pull request)
![screen4](https://cloud.githubusercontent.com/assets/239161/11012538/43128d86-84b2-11e5-9f9f-a84dd77e0426.png)