### PR TITLE
Update mupdf to 1.8

### DIFF
--- a/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
+++ b/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
@@ -380,7 +380,7 @@ JNI_FN(MuPdfDocument_getPageInfo)(JNIEnv *env, jclass cls, jlong handle, jint pa
         fid = (*env)->GetFieldID(env, clazz, "version", "I");
         (*env)->SetIntField(env, cpi, fid, 0);
 
-        fz_free(doc->ctx, page);
+        fz_drop_page(doc->ctx, page);
         return 0;
     }
     return -1;
@@ -541,11 +541,11 @@ JNI_FN(MuPdfPage_open)(JNIEnv *env, jclass clazz, jlong dochandle, jint pageno)
     }
     fz_always(ctx)
     {
-        fz_free(ctx, dev);
+        fz_drop_device(ctx, dev);
     }
     fz_catch(ctx)
     {
-        fz_free(ctx, dev);
+        fz_drop_device(ctx, dev);
         fz_drop_display_list(ctx, page->pageList);
         fz_drop_page(ctx, page->page);
 
@@ -584,7 +584,7 @@ JNI_FN(MuPdfPage_free)(JNIEnv *env, jclass clazz, jlong dochandle, jlong handle)
 
     if (page->page)
     {
-        fz_free(doc->ctx, page->page);
+        fz_drop_page(doc->ctx, page->page);
     }
 
     fz_free(ctx, page);
@@ -690,7 +690,7 @@ JNI_FN(MuPdfPage_renderPageDirect)(JNIEnv *env, jobject this, jlong dochandle,
     }
     fz_always(ctx)
     {
-       fz_free(ctx, dev);
+       fz_drop_device(ctx, dev);
        fz_drop_pixmap(ctx, pixmap);
     }
     fz_catch(ctx)
@@ -826,7 +826,7 @@ JNI_FN(MuPdfPage_search)(JNIEnv * env, jobject thiz, jlong dochandle, jlong page
 
         // DEBUG("MuPdfPage(%p).search(%p, %p): free text device", thiz, doc, page);
 
-        fz_free(doc->ctx, dev);
+        fz_drop_device(doc->ctx, dev);
         dev = NULL;
 
         len = textlen(pagetext);
@@ -873,15 +873,15 @@ JNI_FN(MuPdfPage_search)(JNIEnv * env, jobject thiz, jlong dochandle, jlong page
         // DEBUG("MuPdfPage(%p).search(%p, %p): free resources", thiz, doc, page);
         if (pagetext)
         {
-            fz_free(doc->ctx, pagetext);
+            fz_drop_text_page(doc->ctx, pagetext);
         }
         if (sheet)
         {
-            fz_free(doc->ctx, sheet);
+            fz_drop_text_sheet(doc->ctx, sheet);
         }
         if (dev)
         {
-            fz_free(doc->ctx, dev);
+            fz_drop_device(doc->ctx, dev);
         }
     }fz_catch(doc->ctx)
     {

--- a/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
+++ b/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
@@ -100,7 +100,7 @@ static void mupdf_free_document(renderdocument_t* doc)
 
     if (doc->outline)
     {
-        fz_free(doc->ctx, doc->outline);
+        fz_drop_outline(doc->ctx, doc->outline);
     }
     doc->outline = NULL;
 

--- a/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
+++ b/document-viewer/jni/ebookdroid/mupdfdroidbridge.c
@@ -921,7 +921,7 @@ JNI_FN(MuPdfOutline_free)(JNIEnv *env, jclass clazz, jlong dochandle)
     if (doc)
     {
         if (doc->outline)
-            fz_free(doc->ctx, doc->outline);
+            fz_drop_outline(doc->ctx, doc->outline);
         doc->outline = NULL;
     }
 }

--- a/document-viewer/jni/mupdf/Core.mk
+++ b/document-viewer/jni/mupdf/Core.mk
@@ -14,6 +14,8 @@ LOCAL_SRC_FILES := \
 	mupdf/source/pdf/js/pdf-js.c \
 	mupdf/source/pdf/js/pdf-jsimp-mu.c
 	
+LOCAL_CFLAGS += -DNOCJK
+
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DARCH_ARM -DARCH_THUMB -DARCH_ARM_CAN_LOAD_UNALIGNED
 endif

--- a/document-viewer/jni/mupdf/Core.mk
+++ b/document-viewer/jni/mupdf/Core.mk
@@ -14,8 +14,6 @@ LOCAL_SRC_FILES := \
 	mupdf/source/pdf/js/pdf-js.c \
 	mupdf/source/pdf/js/pdf-jsimp-mu.c
 	
-LOCAL_CFLAGS += -DNOCJK
-
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DARCH_ARM -DARCH_THUMB -DARCH_ARM_CAN_LOAD_UNALIGNED
 endif

--- a/document-viewer/jni/mupdf/ThirdParty.mk
+++ b/document-viewer/jni/mupdf/ThirdParty.mk
@@ -95,7 +95,7 @@ LOCAL_SRC_FILES := \
 	mupdf/thirdparty/freetype/src/base/ftsynth.c \
 	mupdf/thirdparty/freetype/src/base/ftsystem.c \
 	mupdf/thirdparty/freetype/src/base/fttype1.c \
-	mupdf/thirdparty/freetype/src/base/ftxf86.c \
+	mupdf/thirdparty/freetype/src/base/ftfntfmt.c \
 	mupdf/thirdparty/freetype/src/cff/cff.c \
 	mupdf/thirdparty/freetype/src/cid/type1cid.c \
 	mupdf/thirdparty/freetype/src/psaux/psaux.c \

--- a/document-viewer/jni/mupdf/overrides/nightmode_slowcmyk.patch
+++ b/document-viewer/jni/mupdf/overrides/nightmode_slowcmyk.patch
@@ -1,8 +1,8 @@
 diff --git a/include/mupdf/fitz/context.h b/include/mupdf/fitz/context.h
-index 10e28e0..f4368e7 100644
+index cb083f8..46d42dc 100644
 --- a/include/mupdf/fitz/context.h
 +++ b/include/mupdf/fitz/context.h
-@@ -111,6 +111,10 @@ struct fz_context_s
+@@ -113,6 +113,10 @@ struct fz_context_s
  	fz_store *store;
  	fz_glyph_cache *glyph_cache;
  	fz_document_handler_context *handler;
@@ -14,7 +14,7 @@ index 10e28e0..f4368e7 100644
  
  /*
 diff --git a/source/fitz/colorspace.c b/source/fitz/colorspace.c
-index d145be2..9329640 100644
+index 5549496..334c6f4 100644
 --- a/source/fitz/colorspace.c
 +++ b/source/fitz/colorspace.c
 @@ -1,6 +1,8 @@
@@ -56,7 +56,7 @@ index d145be2..9329640 100644
  }
  
  static void rgb_to_cmyk(fz_context *ctx, fz_colorspace *cs, const float *rgb, float *cmyk)
-@@ -619,7 +627,9 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -627,7 +635,9 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  
  	while (n--)
  	{
@@ -67,7 +67,7 @@ index d145be2..9329640 100644
  		unsigned int c = s[0];
  		unsigned int m = s[1];
  		unsigned int y = s[2];
-@@ -748,11 +758,15 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -756,11 +766,15 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  		d[0] = r;
  		d[1] = g;
  		d[2] = b;
@@ -85,7 +85,7 @@ index d145be2..9329640 100644
  		d[3] = s[4];
  		s += 5;
  		d += 4;
-@@ -767,7 +781,9 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -775,7 +789,9 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  	int n = src->w * src->h;
  	while (n--)
  	{
@@ -96,7 +96,7 @@ index d145be2..9329640 100644
  		float cmyk[4], rgb[3];
  		cmyk[0] = s[0] / 255.0f;
  		cmyk[1] = s[1] / 255.0f;
-@@ -777,11 +793,15 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -785,11 +801,15 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  		d[0] = rgb[2] * 255;
  		d[1] = rgb[1] * 255;
  		d[2] = rgb[0] * 255;
@@ -114,7 +114,7 @@ index d145be2..9329640 100644
  		d[3] = s[4];
  		s += 5;
  		d += 4;
-@@ -1090,29 +1110,41 @@ cmyk2g(fz_context *ctx, fz_color_converter *cc, float *dv, const float *sv)
+@@ -1098,29 +1118,41 @@ cmyk2g(fz_context *ctx, fz_color_converter *cc, float *dv, const float *sv)
  static void
  cmyk2rgb(fz_context *ctx, fz_color_converter *cc, float *dv, const float *sv)
  {
@@ -163,10 +163,10 @@ index d145be2..9329640 100644
  
  void fz_lookup_color_converter(fz_context *ctx, fz_color_converter *cc, fz_colorspace *ds, fz_colorspace *ss)
 diff --git a/source/fitz/draw-device.c b/source/fitz/draw-device.c
-index b2819a0..6a90da6 100644
+index fdb631f..ff0f143 100644
 --- a/source/fitz/draw-device.c
 +++ b/source/fitz/draw-device.c
-@@ -1201,6 +1201,9 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
+@@ -1203,6 +1203,9 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
  	fz_pixmap *scaled = NULL;
  	fz_pixmap *pixmap;
  	fz_pixmap *orig_pixmap;
@@ -176,11 +176,11 @@ index b2819a0..6a90da6 100644
  	int dx, dy;
  	int i;
  	fz_draw_state *state = &dev->stack[dev->top];
-@@ -1245,7 +1248,23 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
+@@ -1247,7 +1250,23 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
  			colorbv[i] = colorfv[i] * 255;
  		colorbv[i] = alpha * 255;
  
--		fz_paint_image_with_color(state->dest, &state->scissor, state->shape, pixmap, &local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES));
+-		fz_paint_image_with_color(state->dest, &state->scissor, state->shape, pixmap, &local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES), devp->flags & FZ_DEVFLAG_GRIDFIT_AS_TILED);
 +		// EBD: inverted mode >>>
 +		if (ctx->ebookdroid_nightmode) {
 +			inverted = fz_new_pixmap(ctx, pixmap->colorspace, pixmap->w, pixmap->h);
@@ -189,19 +189,19 @@ index b2819a0..6a90da6 100644
 +
 +			fz_paint_image_with_color(
 +				state->dest, &state->scissor, state->shape, inverted,
-+				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES)
++				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES), devp->flags & FZ_DEVFLAG_GRIDFIT_AS_TILED
 +			);
 +		} else {
 +			fz_paint_image_with_color(
 +				state->dest, &state->scissor, state->shape, pixmap,
-+				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES)
++				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES), devp->flags & FZ_DEVFLAG_GRIDFIT_AS_TILED
 +			);
 +		}
 +		// EBD: inverted mode <<<
  
  		if (scaled)
  			fz_drop_pixmap(ctx, scaled);
-@@ -1255,6 +1274,11 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
+@@ -1257,6 +1276,11 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
  	}
  	fz_always(ctx)
  	{

--- a/document-viewer/jni/mupdf/overrides/nocjk.patch
+++ b/document-viewer/jni/mupdf/overrides/nocjk.patch
@@ -1,0 +1,16 @@
+diff --git a/source/html/html-font.c b/source/html/html-font.c
+index d595b58..0880563 100644
+--- a/source/html/html-font.c
++++ b/source/html/html-font.c
+@@ -21,9 +21,8 @@ fz_load_html_fallback_font(fz_context *ctx, fz_html_font_set *set)
+ 		int index;
+ 
+ 		data = pdf_lookup_substitute_cjk_font(ctx, FZ_ADOBE_GB_1, 0, 0, &size, &index);
+-		if (!data)
+-			fz_throw(ctx, FZ_ERROR_GENERIC, "cannot load fallback font");
+-		set->fallback = fz_new_font_from_memory(ctx, "fallback", data, size, index, 0);
++		if (data)
++			set->fallback = fz_new_font_from_memory(ctx, "fallback", data, size, index, 0);
+ 	}
+ 	return set->fallback;
+ }

--- a/init.sh
+++ b/init.sh
@@ -6,6 +6,7 @@ cd document-viewer/jni/mupdf/mupdf
 make generate
 patch -p1 < ../overrides/fonts.patch
 patch -p1 < ../overrides/nightmode_slowcmyk.patch
+patch -p1 < ../overrides/nocjk.patch
 
 cd ../../djvu/djvulibre
 patch -p1 < ../overrides/remove_print_save_api.patch


### PR DESCRIPTION
Besides updating the submodule commit:
- small update to the mupdf patch we apply (`fz_paint_image_with_color` got an extra argument)
- had to update `document-viewer/jni/mupdf/ThirdParty.mk` due to a file being renamed in Freetype
- change most `fz_free` calls in `document-viewer/jni/ebookdroid/mupdfdroidbridge.c` to the proper `fz_drop_*` call. Was getting crashes when the code tried to `fz_free` an `fz_outline`. The remaining `fz_free()` calls are for `renderpage_t` structures that are allocated in `mupdfdroidbridge.c` with `fz_malloc_no_throw`, so it should be correct to `fz_free` those.

In addition, (possibly undesirable) I had to remove `LOCAL_CFLAGS += -DNOCJK` from Core.mk, or else epubs failed to load. I reported this to the mupdf bugtracker: http://bugs.ghostscript.com/show_bug.cgi?id=696326
NOCJK was also discussed here: https://github.com/SufficientlySecure/document-viewer/issues/115

