### PR TITLE
Change default rotation mode from 'auto' (force auto-rotation) to 'unspecified'

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/common/settings/definitions/AppPreferences.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/settings/definitions/AppPreferences.java
@@ -37,7 +37,7 @@ public interface AppPreferences {
             pref_keepscreenon_defvalue);
 
     EnumPreferenceDefinition<RotationType> ROTATION = new EnumPreferenceDefinition<RotationType>(RotationType.class,
-            pref_rotation_id, pref_rotation_auto);
+            pref_rotation_id, pref_rotation_unspecified);
 
     BooleanPreferenceDefinition FULLSCREEN = new BooleanPreferenceDefinition(pref_fullscreen_id,
             pref_fullscreen_defvalue);


### PR DESCRIPTION
(respect the device's setting).

Since this gets saved in the app preferences it will only affect clean installs / if you clear app data.
Partial fix for https://github.com/SufficientlySecure/document-viewer/issues/147