### PR TITLE
init.sh: specify --force to "git submodule update" to discard local changes in submodules

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git submodule update --init --recursive
+git submodule update --init --recursive --force
 
 cd document-viewer/jni/mupdf/mupdf
 make generate


### PR DESCRIPTION
init.sh applies patches, so this makes it clear out the patches applied by a previous invocation of init.sh.