### PR TITLE
Remove rotation from app settings.

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/common/settings/AppSettings.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/settings/AppSettings.java
@@ -42,8 +42,6 @@ public class AppSettings implements AppPreferences, BookPreferences, IBackupAgen
 
     public final boolean keepScreenOn;
 
-    public final RotationType rotation;
-
     public final boolean fullScreen;
 
     public boolean getShowTitle() {
@@ -182,7 +180,6 @@ public class AppSettings implements AppPreferences, BookPreferences, IBackupAgen
         brightnessInNightModeOnly = BRIGHTNESS_NIGHT_MODE_ONLY.getPreferenceValue(prefs);
         brightness = BRIGHTNESS.getPreferenceValue(prefs);
         keepScreenOn = KEEP_SCREEN_ON.getPreferenceValue(prefs);
-        rotation = ROTATION.getPreferenceValue(prefs);
         fullScreen = FULLSCREEN.getPreferenceValue(prefs);
         pageInTitle = SHOW_PAGE_IN_TITLE.getPreferenceValue(prefs);
         pageNumberToastPosition = PAGE_NUMBER_TOAST_POSITION.getPreferenceValue(prefs);
@@ -420,7 +417,6 @@ public class AppSettings implements AppPreferences, BookPreferences, IBackupAgen
     public static class Diff {
 
         private static final int D_Lang = 0x0001 << 0;
-        private static final int D_Rotation = 0x0001 << 1;
         private static final int D_FullScreen = 0x0001 << 2;
         private static final int D_PageInTitle = 0x0001 << 4;
         private static final int D_TapsEnabled = 0x0001 << 5;
@@ -447,9 +443,6 @@ public class AppSettings implements AppPreferences, BookPreferences, IBackupAgen
             } else if (news != null) {
                 if (CompareUtils.compare(olds.lang, news.lang) != 0) {
                     mask |= D_Lang;
-                }
-                if (olds.rotation != news.rotation) {
-                    mask |= D_Rotation;
                 }
                 if (olds.fullScreen != news.fullScreen) {
                     mask |= D_FullScreen;
@@ -496,10 +489,6 @@ public class AppSettings implements AppPreferences, BookPreferences, IBackupAgen
 
         public boolean isLangChanged() {
             return 0 != (mask & D_Lang);
-        }
-
-        public boolean isRotationChanged() {
-            return 0 != (mask & D_Rotation);
         }
 
         public boolean isFullScreenChanged() {

--- a/document-viewer/src/main/java/org/ebookdroid/common/settings/books/BookSettings.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/settings/books/BookSettings.java
@@ -237,8 +237,8 @@ public class BookSettings implements CurrentPageListener {
         }
     }
 
-    public int getOrientation(final AppSettings appSettings) {
-        final RotationType defRotation = appSettings.rotation;
+    public int getOrientation() {
+        final RotationType defRotation = RotationType.UNSPECIFIED;
         return rotation != null ? rotation.getOrientation(defRotation) : defRotation.getOrientation();
     }
 

--- a/document-viewer/src/main/java/org/ebookdroid/common/settings/definitions/AppPreferences.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/settings/definitions/AppPreferences.java
@@ -36,9 +36,6 @@ public interface AppPreferences {
     BooleanPreferenceDefinition KEEP_SCREEN_ON = new BooleanPreferenceDefinition(pref_keepscreenon_id,
             pref_keepscreenon_defvalue);
 
-    EnumPreferenceDefinition<RotationType> ROTATION = new EnumPreferenceDefinition<RotationType>(RotationType.class,
-            pref_rotation_id, pref_rotation_auto);
-
     BooleanPreferenceDefinition FULLSCREEN = new BooleanPreferenceDefinition(pref_fullscreen_id,
             pref_fullscreen_defvalue);
 

--- a/document-viewer/src/main/java/org/ebookdroid/common/settings/types/RotationType.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/settings/types/RotationType.java
@@ -21,43 +21,7 @@ public enum RotationType implements ResourceConstant {
     /**
     *
     */
-    PORTRAIT(R.string.pref_rotation_port, ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, 3),
-    /**
-   *
-   */
-    USER(R.string.pref_rotation_user, ActivityInfo.SCREEN_ORIENTATION_USER, 3),
-    /**
-    *
-    */
-    BEHIND(R.string.pref_rotation_behind, ActivityInfo.SCREEN_ORIENTATION_BEHIND, 3),
-    /**
-    *
-    */
-    AUTOMATIC(R.string.pref_rotation_auto, ActivityInfo.SCREEN_ORIENTATION_SENSOR, 3),
-    /**
-    *
-    */
-    NOSENSOR(R.string.pref_rotation_nosensor, ActivityInfo.SCREEN_ORIENTATION_NOSENSOR, 3),
-    /**
-    * Not compatible with of versions
-    */
-    SENSOR_LANDSCAPE(R.string.pref_rotation_sensor_landscape, 6 /* ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE */, 10),
-    /**
-    *
-    */
-    SENSOR_PORTRAIT(R.string.pref_rotation_sensor_portrait, 7 /* ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT */, 10),
-    /**
-    *
-    */
-    REVERSE_LANDSCAPE(R.string.pref_rotation_reverse_landscape, 8 /* ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE */, 10),
-    /**
-    *
-    */
-    REVERSE_PORTRAIT(R.string.pref_rotation_reverse_portrait, 9 /* ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT */, 10),
-    /**
-    *
-    */
-    FULL_SENSOR(R.string.pref_rotation_full_sensor, 10 /* ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR */, 10);
+    PORTRAIT(R.string.pref_rotation_port, ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, 3);
 
     private final String resValue;
 

--- a/document-viewer/src/main/java/org/ebookdroid/ui/settings/BookSettingsActivity.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/settings/BookSettingsActivity.java
@@ -29,7 +29,7 @@ public class BookSettingsActivity extends BaseSettingsActivity {
             return;
         }
 
-        setRequestedOrientation(current.getOrientation(AppSettings.current()));
+        setRequestedOrientation(current.getOrientation());
 
         SettingsManager.onBookSettingsActivityCreated(current);
 

--- a/document-viewer/src/main/java/org/ebookdroid/ui/settings/SettingsActivity.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/settings/SettingsActivity.java
@@ -27,7 +27,7 @@ public class SettingsActivity extends BaseSettingsActivity {
             final String fileName = PathFromUri.retrieve(getContentResolver(), uri);
             BookSettings current = SettingsManager.getBookSettings(fileName);
             if (current != null) {
-                setRequestedOrientation(current.getOrientation(AppSettings.current()));
+                setRequestedOrientation(current.getOrientation());
             }
         }
 

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -147,7 +147,6 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
     public void beforeCreate(final ViewerActivity activity) {
         final AppSettings newSettings = AppSettings.current();
 
-        activity.setRequestedOrientation(newSettings.rotation.getOrientation());
         IUIManager.instance.setTitleVisible(activity, newSettings.getShowTitle(), true);
 
         TouchManager.loadFromSettings(newSettings);
@@ -163,7 +162,6 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
     public void beforeRecreate(final ViewerActivity activity) {
         final AppSettings newSettings = AppSettings.current();
 
-        activity.setRequestedOrientation(newSettings.rotation.getOrientation());
         IUIManager.instance.setTitleVisible(activity, newSettings.getShowTitle(), true);
 
         TouchManager.loadFromSettings(newSettings);
@@ -861,13 +859,6 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
     public void onAppSettingsChanged(final AppSettings oldSettings, final AppSettings newSettings,
             final AppSettings.Diff diff) {
         final ViewerActivity activity = getManagedComponent();
-        if (diff.isRotationChanged()) {
-            if (bookSettings != null) {
-                activity.setRequestedOrientation(bookSettings.getOrientation(newSettings));
-            } else {
-                activity.setRequestedOrientation(newSettings.rotation.getOrientation());
-            }
-        }
 
         if (diff.isFullScreenChanged()) {
             IUIManager.instance.setFullScreenMode(activity, activity.view.getView(), newSettings.fullScreen);
@@ -917,7 +908,7 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
         }
 
         if (diff.isRotationChanged()) {
-            getManagedComponent().setRequestedOrientation(newSettings.getOrientation(AppSettings.current()));
+            getManagedComponent().setRequestedOrientation(newSettings.getOrientation());
         }
 
         if (diff.isFirstTime()) {

--- a/document-viewer/src/main/res/values/service_preferences_render.xml
+++ b/document-viewer/src/main/res/values/service_preferences_render.xml
@@ -5,65 +5,6 @@
     <string translatable="false" name="pref_rotation_unspecified">Unspecified</string>
     <string translatable="false" name="pref_rotation_land">Force landscape</string>
     <string translatable="false" name="pref_rotation_port">Force portrait</string>
-    <string translatable="false" name="pref_rotation_user">User</string>
-    <string translatable="false" name="pref_rotation_behind">Behind</string>
-    <string translatable="false" name="pref_rotation_auto">Automatic</string>
-    <string translatable="false" name="pref_rotation_nosensor">No sensor</string>
-    <string translatable="false" name="pref_rotation_sensor_landscape">Sensor landscape</string>
-    <string translatable="false" name="pref_rotation_sensor_portrait">Sensor portrait</string>
-    <string translatable="false" name="pref_rotation_reverse_landscape">Reverse landscape</string>
-    <string translatable="false" name="pref_rotation_reverse_portrait">Reverse portrait</string>
-    <string translatable="false" name="pref_rotation_full_sensor">Full sensor</string>
-
-    <string-array name="pref_rotation_entries_3" translatable="false">
-        <item>@string/list_rotation_unspecified</item>
-        <item>@string/list_rotation_land</item>
-        <item>@string/list_rotation_port</item>
-        <item>@string/list_rotation_user</item>
-        <item>@string/list_rotation_behind</item>
-        <item>@string/list_rotation_auto</item>
-        <item>@string/list_rotation_nosensor</item>
-    </string-array>
-
-    <string-array name="pref_rotation_values_3" translatable="false">
-        <item>@string/pref_rotation_unspecified</item>
-        <item>@string/pref_rotation_land</item>
-        <item>@string/pref_rotation_port</item>
-        <item>@string/pref_rotation_user</item>
-        <item>@string/pref_rotation_behind</item>
-        <item>@string/pref_rotation_auto</item>
-        <item>@string/pref_rotation_nosensor</item>
-    </string-array>
-
-    <string-array name="pref_rotation_entries_10" translatable="false">
-        <item>@string/list_rotation_unspecified</item>
-        <item>@string/list_rotation_land</item>
-        <item>@string/list_rotation_port</item>
-        <item>@string/list_rotation_user</item>
-        <item>@string/list_rotation_behind</item>
-        <item>@string/list_rotation_auto</item>
-        <item>@string/list_rotation_nosensor</item>
-        <item>@string/list_rotation_sensor_landscape</item>
-        <item>@string/list_rotation_sensor_portrait</item>
-        <item>@string/list_rotation_reverse_landscape</item>
-        <item>@string/list_rotation_reverse_portrait</item>
-        <item>@string/list_rotation_full_sensor</item>
-    </string-array>
-
-    <string-array name="pref_rotation_values_10" translatable="false">
-        <item>@string/pref_rotation_unspecified</item>
-        <item>@string/pref_rotation_land</item>
-        <item>@string/pref_rotation_port</item>
-        <item>@string/pref_rotation_user</item>
-        <item>@string/pref_rotation_behind</item>
-        <item>@string/pref_rotation_auto</item>
-        <item>@string/pref_rotation_nosensor</item>
-        <item>@string/pref_rotation_sensor_landscape</item>
-        <item>@string/pref_rotation_sensor_portrait</item>
-        <item>@string/pref_rotation_reverse_landscape</item>
-        <item>@string/pref_rotation_reverse_portrait</item>
-        <item>@string/pref_rotation_full_sensor</item>
-    </string-array>
 
     <string translatable="false" name="pref_nightmode_id">nightmode</string>
     <string translatable="false" name="pref_nightmode_defvalue">false</string>

--- a/document-viewer/src/main/res/values/strings_preferences_render.xml
+++ b/document-viewer/src/main/res/values/strings_preferences_render.xml
@@ -7,15 +7,6 @@
     <string name="list_rotation_unspecified">Unspecified</string>
     <string name="list_rotation_land">Force landscape</string>
     <string name="list_rotation_port">Force portrait</string>
-    <string name="list_rotation_user">User</string>
-    <string name="list_rotation_behind">Inherit from background</string>
-    <string name="list_rotation_auto">Automatic</string>
-    <string name="list_rotation_nosensor">No sensor</string>
-    <string name="list_rotation_sensor_landscape">Force landscape but sense flipping</string>
-    <string name="list_rotation_sensor_portrait">Force portrait but sense flipping</string>
-    <string name="list_rotation_reverse_landscape">Force reverse landscape</string>
-    <string name="list_rotation_reverse_portrait">Force reverse portrait</string>
-    <string name="list_rotation_full_sensor">Full sensor</string>
 
     <string name="pref_render_category">Rendering</string>
     <string name="pref_render_category_summary">Rendering settings</string>

--- a/document-viewer/src/main/res/xml-v10/fragment_render.xml
+++ b/document-viewer/src/main/res/xml-v10/fragment_render.xml
@@ -4,14 +4,6 @@
     android:summary="@string/pref_render_category_summary"
     android:title="@string/pref_render_category" >
 
-    <ListPreference
-            android:defaultValue="@string/pref_rotation_auto"
-            android:entries="@array/pref_rotation_entries_10"
-            android:entryValues="@array/pref_rotation_values_10"
-            android:key="@string/pref_rotation_id"
-            android:summary="@string/pref_rotation_summary"
-            android:title="@string/pref_rotation_title" />
-
     <CheckBoxPreference
             android:defaultValue="@string/pref_splitpages_defvalue"
             android:key="@string/pref_splitpages_id"

--- a/document-viewer/src/main/res/xml-v14/fragment_render.xml
+++ b/document-viewer/src/main/res/xml-v14/fragment_render.xml
@@ -4,14 +4,6 @@
     android:summary="@string/pref_render_category_summary"
     android:title="@string/pref_render_category" >
 
-    <ListPreference
-            android:defaultValue="@string/pref_rotation_auto"
-            android:entries="@array/pref_rotation_entries_10"
-            android:entryValues="@array/pref_rotation_values_10"
-            android:key="@string/pref_rotation_id"
-            android:summary="@string/pref_rotation_summary"
-            android:title="@string/pref_rotation_title" />
-
     <org.emdev.ui.preference.SwitchPreferenceEx
             android:defaultValue="@string/pref_splitpages_defvalue"
             android:key="@string/pref_splitpages_id"

--- a/document-viewer/src/main/res/xml/fragment_render.xml
+++ b/document-viewer/src/main/res/xml/fragment_render.xml
@@ -4,14 +4,6 @@
     android:summary="@string/pref_render_category_summary"
     android:title="@string/pref_render_category" >
 
-    <ListPreference
-            android:defaultValue="@string/pref_rotation_auto"
-            android:entries="@array/pref_rotation_entries_3"
-            android:entryValues="@array/pref_rotation_values_3"
-            android:key="@string/pref_rotation_id"
-            android:summary="@string/pref_rotation_summary"
-            android:title="@string/pref_rotation_title" />
-
     <CheckBoxPreference
             android:defaultValue="@string/pref_splitpages_defvalue"
             android:key="@string/pref_splitpages_id"


### PR DESCRIPTION
It's still present as a book setting, with the same options (unspecified, portrait, landscape) as before, and the toolbar buttons still work as expected.