### PR TITLE
Use correct extension for temporary files for content:// data

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/CodecType.java
+++ b/document-viewer/src/main/java/org/ebookdroid/CodecType.java
@@ -98,4 +98,8 @@ public enum CodecType {
     public static CodecType getByMimeType(final String type) {
         return mimeTypesToActivity.get(type.toLowerCase());
     }
+
+    public String getDefaultExtension() {
+        return extensions.get(0);
+    }
 }

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -962,7 +962,7 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
         protected Throwable doInBackground(final String... params) {
             LCTX.d("BookLoadTask.doInBackground(): start");
             try {
-                final File cached = scheme.loadToCache(intent.getData(), this);
+                final File cached = scheme.loadToCache(intent.getData(), codecType.getDefaultExtension(), this);
                 if (cached != null) {
                     m_fileName = cached.getAbsolutePath();
                     setProgressDialogMessage(startProgressStringId);

--- a/document-viewer/src/main/java/org/emdev/common/cache/CacheManager.java
+++ b/document-viewer/src/main/java/org/emdev/common/cache/CacheManager.java
@@ -88,8 +88,8 @@ public class CacheManager {
         return tempfile;
     }
 
-    public static File createTempFile(final Uri uri, final UIFileCopying worker) throws IOException {
-        final File tempfile = File.createTempFile("temp", "content", s_cacheDir);
+    public static File createTempFile(final Uri uri, final String extension, final UIFileCopying worker) throws IOException {
+        final File tempfile = File.createTempFile("temp", "content." + extension, s_cacheDir);
         tempfile.deleteOnExit();
 
         final InputStream source = s_context.getContentResolver().openInputStream(uri);

--- a/document-viewer/src/main/java/org/emdev/common/content/ContentScheme.java
+++ b/document-viewer/src/main/java/org/emdev/common/content/ContentScheme.java
@@ -28,9 +28,9 @@ public enum ContentScheme {
     CONTENT("content", "[E-mail Attachment]", false) {
 
         @Override
-        public File loadToCache(final Uri uri, final IProgressIndicator progress) throws IOException {
+        public File loadToCache(final Uri uri, final String extension, final IProgressIndicator progress) throws IOException {
             final UIFileCopying ui = new UIFileCopying(R.string.msg_loading_book, 64 * 1024, progress);
-            return CacheManager.createTempFile(uri, ui);
+            return CacheManager.createTempFile(uri, extension, ui);
         }
 
         @Override
@@ -53,7 +53,7 @@ public enum ContentScheme {
     SMB("smb", "[SMB source]", true) {
 
         @Override
-        public File loadToCache(final Uri uri, final IProgressIndicator progress) throws IOException {
+        public File loadToCache(final Uri uri, final String extension, final IProgressIndicator progress) throws IOException {
             final UIFileCopying ui = new UIFileCopying(R.string.opds_loading_book, 64 * 1024, progress);
             return CacheManager.createTempDocument(new SmbFileInputStream(uri.toString()), uri.getLastPathSegment(), ui);
         }
@@ -62,7 +62,7 @@ public enum ContentScheme {
     HTTP("http", "[HTTP source]", true) {
 
         @Override
-        public File loadToCache(final Uri uri, final IProgressIndicator progress) throws IOException {
+        public File loadToCache(final Uri uri, final String extension, final IProgressIndicator progress) throws IOException {
             return loadFromURL(uri, progress);
         }
     },
@@ -70,7 +70,7 @@ public enum ContentScheme {
     HTTPS("https", "[HTTPS source]", true) {
 
         @Override
-        public File loadToCache(final Uri uri, final IProgressIndicator progress) throws IOException {
+        public File loadToCache(final Uri uri, final String extension, final IProgressIndicator progress) throws IOException {
             return loadFromURL(uri, progress);
         }
     },
@@ -115,7 +115,7 @@ public enum ContentScheme {
         this.promptForSave = promptForSave;
     }
 
-    public File loadToCache(final Uri uri, final IProgressIndicator progress) throws IOException {
+    public File loadToCache(final Uri uri, final String extension, final IProgressIndicator progress) throws IOException {
         return null;
     }
 


### PR DESCRIPTION
Fixes https://github.com/SufficientlySecure/document-viewer/issues/149 (epub files not loading from the Downloads app.)