### PR TITLE
DecodeServiceBase.calculateRootCropping(): remove goToPage call

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/core/DecodeServiceBase.java
+++ b/document-viewer/src/main/java/org/ebookdroid/core/DecodeServiceBase.java
@@ -294,14 +294,6 @@ public class DecodeServiceBase implements DecodeService {
                     + croppedPageBounds);
         }
 
-        task.node.page.base.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                viewState.ctrl.goToPage(currentPage.viewIndex, offsetX, offsetY);
-            }
-        });
-
         return croppedPageBounds;
     }
 


### PR DESCRIPTION
as discussed here: https://github.com/SufficientlySecure/document-viewer/issues/89

I thought I would make a pr for this. I'll keep testing it.

Agree in general we don't want to make changes without understanding the code.
The bug this fixes is pretty annoying though. 