### PR TITLE
Fix for closing the file browser or OPDS activity also closing the Library

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/ui/library/BrowserActivity.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/library/BrowserActivity.java
@@ -133,14 +133,14 @@ public class BrowserActivity extends AbstractActionActivity<BrowserActivity, Bro
     /**
      * {@inheritDoc}
      *
-     * @see android.app.Activity#onKeyDown(int, android.view.KeyEvent)
+     * @see android.app.Activity#onKeyUp(int, android.view.KeyEvent)
      */
     @Override
-    public boolean onKeyDown(final int keyCode, final KeyEvent event) {
-        if (getController().onKeyDown(keyCode, event)) {
+    public boolean onKeyUp(final int keyCode, final KeyEvent event) {
+        if (getController().onKeyUp(keyCode, event)) {
             return true;
         }
-        return super.onKeyDown(keyCode, event);
+        return super.onKeyUp(keyCode, event);
     }
 
     public void showProgress(final boolean show) {

--- a/document-viewer/src/main/java/org/ebookdroid/ui/library/BrowserActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/library/BrowserActivityController.java
@@ -100,8 +100,8 @@ public class BrowserActivityController extends AbstractActivityController<Browse
         showProgress(false);
     }
 
-    public boolean onKeyDown(final int keyCode, final KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
+    public boolean onKeyUp(final int keyCode, final KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && !event.isCanceled()) {
             final File dir = adapter.getCurrentDirectory();
             final File parent = dir != null ? dir.getParentFile() : null;
             if (parent != null) {

--- a/document-viewer/src/main/java/org/ebookdroid/ui/library/RecentActivity.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/library/RecentActivity.java
@@ -259,20 +259,6 @@ public class RecentActivity extends AbstractActionActivity<RecentActivity, Recen
         menu.setHeaderTitle(a.name);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see android.app.Activity#onKeyUp(int, android.view.KeyEvent)
-     */
-    @Override
-    public boolean onKeyUp(final int keyCode, final KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK && !event.isCanceled()) {
-            getController().getOrCreateAction(R.id.mainmenu_close).run();
-            return true;
-        }
-        return super.onKeyUp(keyCode, event);
-    }
-
     void changeLibraryView(final int view) {
         final ViewFlipper vf = getViewflipper();
         if (view == VIEW_LIBRARY) {

--- a/document-viewer/src/main/java/org/ebookdroid/ui/opds/OPDSActivity.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/opds/OPDSActivity.java
@@ -66,11 +66,11 @@ public class OPDSActivity extends AbstractActionActivity<OPDSActivity, OPDSActiv
     /**
      * {@inheritDoc}
      *
-     * @see android.app.Activity#onKeyDown(int, android.view.KeyEvent)
+     * @see android.app.Activity#onKeyUp(int, android.view.KeyEvent)
      */
     @Override
-    public boolean onKeyDown(final int keyCode, final KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
+    public boolean onKeyUp(final int keyCode, final KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && !event.isCanceled()) {
             final Feed current = getController().adapter.getCurrentFeed();
             if (current == null) {
                 finish();
@@ -79,7 +79,7 @@ public class OPDSActivity extends AbstractActionActivity<OPDSActivity, OPDSActiv
             }
             return true;
         }
-        return super.onKeyDown(keyCode, event);
+        return super.onKeyUp(keyCode, event);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/SufficientlySecure/document-viewer/issues/124
Also, makes the file browser and OPDS activity close on keyUp (rather than keyDown, as before) of the Back button.