### PR TITLE
Don't call System.exit(0) when last activity closes

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/EBookDroidApp.java
+++ b/document-viewer/src/main/java/org/ebookdroid/EBookDroidApp.java
@@ -130,16 +130,6 @@ public class EBookDroidApp extends BaseDroidApp implements IAppSettingsChangeLis
 //        }
     }
 
-    public static void onActivityClose(final boolean finishing) {
-        if (finishing && !SettingsManager.hasOpenedBooks() && !RecentActivityController.working.get()) {
-            if (instance != null) {
-                instance.onTerminate();
-            }
-            Log.i(APP_NAME, "Application finished");
-            System.exit(0);
-        }
-    }
-
     /**
      * Preallocate heap.
      *

--- a/document-viewer/src/main/java/org/ebookdroid/ui/library/RecentActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/library/RecentActivityController.java
@@ -165,8 +165,6 @@ public class RecentActivityController extends AbstractActivityController<RecentA
             CacheManager.listeners.removeListener(this);
             SettingsManager.removeListener(this);
             MediaManager.listeners.removeListener(this);
-
-            EBookDroidApp.onActivityClose(finishing);
         }
     }
 

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -293,12 +293,6 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
             SettingsManager.removeListener(this);
             BitmapManager.clear("on finish");
             ByteBufferManager.clear("on finish");
-
-            if (getOrCreateAction(R.id.actions_doClose).getParameter("up", Boolean.FALSE).booleanValue()) {
-                LCTX.i("Skipping EBookDroidApp.onActivityClose(), which would kill the process, because we are currently navigating up");
-            } else {
-                EBookDroidApp.onActivityClose(finishing);
-            }
         }
     }
 


### PR DESCRIPTION
AFAIK this is considered bad practice on Android - it's supposed to be left up to the OS, and it slows down app startup because the process has to be started from scratch.