### PR TITLE
GLES configuration: fall back to EGL_STENCIL_SIZE 0, if 1 is not available

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/EBookDroidApp.java
+++ b/document-viewer/src/main/java/org/ebookdroid/EBookDroidApp.java
@@ -60,8 +60,6 @@ public class EBookDroidApp extends BaseDroidApp implements IAppSettingsChangeLis
         onAppSettingsChanged(null, AppSettings.current(), null);
         onBackupSettingsChanged(null, BackupSettings.current(), null);
 
-        GLConfiguration.stencilRequired = !IS_EMULATOR;
-
         initialized.set();
     }
 

--- a/document-viewer/src/main/java/org/emdev/ui/gl/GLConfiguration.java
+++ b/document-viewer/src/main/java/org/emdev/ui/gl/GLConfiguration.java
@@ -8,8 +8,6 @@ import javax.microedition.khronos.egl.EGLDisplay;
 
 public class GLConfiguration {
 
-    public static boolean stencilRequired = true;
-
     public static boolean use8888 = false;
 
     private static BaseEGLConfigChooser chooser;


### PR DESCRIPTION
Previously, we were requesting 1 on non-emulators, and 0 on emulators, because emulators use Android's software GLES implementation that doesn't support stencil.
That meant the app wouldn't run on devices without stencil support.

This should fix https://github.com/SufficientlySecure/document-viewer/issues/94