### PR TITLE
Add "Share" and "Open with..." menu items

### DIFF
--- a/document-viewer/src/main/AndroidManifest.xml
+++ b/document-viewer/src/main/AndroidManifest.xml
@@ -26,6 +26,11 @@
         android:theme="@style/ebookdroid"
         android:largeHeap="true">
 
+        <provider
+            android:name="org.ebookdroid.common.provider.DocumentContentProvider"
+            android:authorities="org.ebookdroid.document"
+            android:exported="true" />
+
         <meta-data android:name="com.sec.android.support.multiwindow" android:value="true"/>
         <activity
             android:name="org.ebookdroid.ui.viewer.ViewerActivity"

--- a/document-viewer/src/main/AndroidManifest.xml
+++ b/document-viewer/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         <provider
             android:name="org.ebookdroid.common.provider.DocumentContentProvider"
             android:authorities="org.ebookdroid.document"
-            android:exported="true" />
+            android:grantUriPermissions="true"
+            android:exported="false" />
 
         <meta-data android:name="com.sec.android.support.multiwindow" android:value="true"/>
         <activity

--- a/document-viewer/src/main/java/org/ebookdroid/common/provider/DocumentContentProvider.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/provider/DocumentContentProvider.java
@@ -1,0 +1,54 @@
+package org.ebookdroid.common.provider;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+public class DocumentContentProvider extends ContentProvider {
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        File file = new File(uri.getPath());
+
+        if (file.exists()) {
+            return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+        }
+
+        throw new FileNotFoundException(uri.getPath());
+    }
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return uri.getQuery();
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues contentValues) {
+        return uri;
+    }
+
+    @Override
+    public int delete(Uri uri, String s, String[] strings) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+        return 0;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+        return null;
+    }
+}

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -770,6 +770,7 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
         }
 
         Intent share = new Intent(Intent.ACTION_SEND);
+        share.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         share.putExtra(Intent.EXTRA_STREAM, uri);
         share.setType(mimeType);
 

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -752,9 +752,12 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
         return false;
     }
 
-    @ActionMethod(ids = R.id.mainmenu_share)
-    public void shareDocument(final ActionEx action) {
-        final String mimeType = codecType.mimeTypes.get(0);
+    private String getShareMimeType() {
+        return codecType.mimeTypes.get(0);
+    }
+
+    private Uri getShareURI() {
+        final String mimeType = getShareMimeType();
         Uri.Builder builder = new Uri.Builder();
         Uri uri;
         if (scheme.temporary) {
@@ -768,13 +771,26 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
             builder.path(m_fileName);
             uri = builder.build();
         }
+        return uri;
+    }
 
+    @ActionMethod(ids = R.id.mainmenu_share)
+    public void shareDocument(final ActionEx action) {
         Intent share = new Intent(Intent.ACTION_SEND);
         share.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        share.putExtra(Intent.EXTRA_STREAM, uri);
-        share.setType(mimeType);
+        share.putExtra(Intent.EXTRA_STREAM, getShareURI());
+        share.setType(getShareMimeType());
 
-        getManagedComponent().startActivity(Intent.createChooser(share, "Share..."));
+        getManagedComponent().startActivity(Intent.createChooser(share, getManagedComponent().getString(R.string.menu_share)));
+    }
+
+    @ActionMethod(ids = R.id.mainmenu_openwith)
+    public void openWith(final ActionEx action) {
+        Intent openwith = new Intent(Intent.ACTION_VIEW);
+        openwith.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        openwith.setDataAndType(getShareURI(), getShareMimeType());
+
+        getManagedComponent().startActivity(Intent.createChooser(openwith, getManagedComponent().getString(R.string.menu_openwith)));
     }
 
     @ActionMethod(ids = R.id.mainmenu_close)

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -752,6 +752,30 @@ public class ViewerActivityController extends AbstractActivityController<ViewerA
         return false;
     }
 
+    @ActionMethod(ids = R.id.mainmenu_share)
+    public void shareDocument(final ActionEx action) {
+        final String mimeType = codecType.mimeTypes.get(0);
+        Uri.Builder builder = new Uri.Builder();
+        Uri uri;
+        if (scheme.temporary) {
+            builder.scheme("content");
+            builder.authority("org.ebookdroid.document");
+            builder.path(m_fileName);
+            builder.query(mimeType);
+            uri = builder.build();
+        } else {
+            builder.scheme("file");
+            builder.path(m_fileName);
+            uri = builder.build();
+        }
+
+        Intent share = new Intent(Intent.ACTION_SEND);
+        share.putExtra(Intent.EXTRA_STREAM, uri);
+        share.setType(mimeType);
+
+        getManagedComponent().startActivity(Intent.createChooser(share, "Share..."));
+    }
+
     @ActionMethod(ids = R.id.mainmenu_close)
     public void closeActivity(final ActionEx action) {
         if (scheme == null || !scheme.promptForSave) {

--- a/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
@@ -107,6 +107,10 @@
         </menu>
     </item>
     <item
+        android:id="@+id/mainmenu_share"
+        android:icon="@drawable/common_actionbar_about"
+        android:title="@string/menu_share"/>
+    <item
         android:id="@+id/mainmenu_about"
         android:icon="@drawable/common_actionbar_about"
         android:showAsAction="always"

--- a/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
@@ -108,7 +108,6 @@
     </item>
     <item
         android:id="@+id/mainmenu_share"
-        android:icon="@drawable/common_actionbar_about"
         android:title="@string/menu_share"/>
     <item
         android:id="@+id/mainmenu_about"

--- a/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
@@ -108,9 +108,11 @@
     </item>
     <item
         android:id="@+id/mainmenu_share"
+        android:showAsAction="never"
         android:title="@string/menu_share"/>
     <item
         android:id="@+id/mainmenu_openwith"
+        android:showAsAction="never"
         android:title="@string/menu_openwith"/>
     <item
         android:id="@+id/mainmenu_about"

--- a/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-sw600dp-v11/mainmenu.xml
@@ -110,6 +110,9 @@
         android:id="@+id/mainmenu_share"
         android:title="@string/menu_share"/>
     <item
+        android:id="@+id/mainmenu_openwith"
+        android:title="@string/menu_openwith"/>
+    <item
         android:id="@+id/mainmenu_about"
         android:icon="@drawable/common_actionbar_about"
         android:showAsAction="always"

--- a/document-viewer/src/main/res/menu-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-v11/mainmenu.xml
@@ -98,7 +98,6 @@
         android:title="@string/menu_key_bindings"/>
     <item
         android:id="@+id/mainmenu_share"
-        android:icon="@drawable/common_actionbar_about"
         android:title="@string/menu_share"/>
     <item
         android:id="@+id/mainmenu_about"

--- a/document-viewer/src/main/res/menu-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-v11/mainmenu.xml
@@ -100,6 +100,9 @@
         android:id="@+id/mainmenu_share"
         android:title="@string/menu_share"/>
     <item
+        android:id="@+id/mainmenu_openwith"
+        android:title="@string/menu_openwith"/>
+    <item
         android:id="@+id/mainmenu_about"
         android:icon="@drawable/common_actionbar_about"
         android:showAsAction="never"

--- a/document-viewer/src/main/res/menu-v11/mainmenu.xml
+++ b/document-viewer/src/main/res/menu-v11/mainmenu.xml
@@ -97,6 +97,10 @@
         android:showAsAction="never"
         android:title="@string/menu_key_bindings"/>
     <item
+        android:id="@+id/mainmenu_share"
+        android:icon="@drawable/common_actionbar_about"
+        android:title="@string/menu_share"/>
+    <item
         android:id="@+id/mainmenu_about"
         android:icon="@drawable/common_actionbar_about"
         android:showAsAction="never"

--- a/document-viewer/src/main/res/menu/mainmenu.xml
+++ b/document-viewer/src/main/res/menu/mainmenu.xml
@@ -98,6 +98,9 @@
         android:id="@+id/mainmenu_share"
         android:title="@string/menu_share"/>
     <item
+        android:id="@+id/mainmenu_openwith"
+        android:title="@string/menu_openwith"/>
+    <item
         android:id="@+id/mainmenu_about"
         android:icon="@drawable/common_actionbar_about"
         android:title="@string/menu_about"/>

--- a/document-viewer/src/main/res/menu/mainmenu.xml
+++ b/document-viewer/src/main/res/menu/mainmenu.xml
@@ -95,6 +95,10 @@
         </menu>
     </item>
     <item
+        android:id="@+id/mainmenu_share"
+        android:icon="@drawable/common_actionbar_about"
+        android:title="@string/menu_share"/>
+    <item
         android:id="@+id/mainmenu_about"
         android:icon="@drawable/common_actionbar_about"
         android:title="@string/menu_about"/>

--- a/document-viewer/src/main/res/menu/mainmenu.xml
+++ b/document-viewer/src/main/res/menu/mainmenu.xml
@@ -96,7 +96,6 @@
     </item>
     <item
         android:id="@+id/mainmenu_share"
-        android:icon="@drawable/common_actionbar_about"
         android:title="@string/menu_share"/>
     <item
         android:id="@+id/mainmenu_about"

--- a/document-viewer/src/main/res/menu/mainmenu_context.xml
+++ b/document-viewer/src/main/res/menu/mainmenu_context.xml
@@ -76,7 +76,6 @@
     </item>
     <item
         android:id="@+id/mainmenu_share"
-        android:icon="@drawable/common_actionbar_about"
         android:title="@string/menu_share"/>
     <item
         android:id="@+id/mainmenu_settings_menu"

--- a/document-viewer/src/main/res/menu/mainmenu_context.xml
+++ b/document-viewer/src/main/res/menu/mainmenu_context.xml
@@ -75,6 +75,10 @@
             </menu>
     </item>
     <item
+        android:id="@+id/mainmenu_share"
+        android:icon="@drawable/common_actionbar_about"
+        android:title="@string/menu_share"/>
+    <item
         android:id="@+id/mainmenu_settings_menu"
         android:icon="@drawable/viewer_actionbar_menu_settings"
         android:title="@string/menu_allsettings_menu">

--- a/document-viewer/src/main/res/menu/mainmenu_context.xml
+++ b/document-viewer/src/main/res/menu/mainmenu_context.xml
@@ -78,6 +78,9 @@
         android:id="@+id/mainmenu_share"
         android:title="@string/menu_share"/>
     <item
+        android:id="@+id/mainmenu_openwith"
+        android:title="@string/menu_openwith"/>
+    <item
         android:id="@+id/mainmenu_settings_menu"
         android:icon="@drawable/viewer_actionbar_menu_settings"
         android:title="@string/menu_allsettings_menu">

--- a/document-viewer/src/main/res/values/strings_mainmenu.xml
+++ b/document-viewer/src/main/res/values/strings_mainmenu.xml
@@ -26,6 +26,7 @@
     <string name="menu_allsettings_menu">Settings...</string>
 
     <string name="menu_share">Share...</string>
+    <string name="menu_openwith">Open with...</string>
 
     <string name="menu_show_library">Show library</string>
     <string name="menu_show_recent">Show recent</string>

--- a/document-viewer/src/main/res/values/strings_mainmenu.xml
+++ b/document-viewer/src/main/res/values/strings_mainmenu.xml
@@ -25,6 +25,8 @@
     <string name="menu_fastsettings_menu">View...</string>
     <string name="menu_allsettings_menu">Settings...</string>
 
+    <string name="menu_share">Share...</string>
+
     <string name="menu_show_library">Show library</string>
     <string name="menu_show_recent">Show recent</string>
     <string name="menu_storages">Storages</string>


### PR DESCRIPTION
This is @fid-jose 's pull request https://github.com/SufficientlySecure/document-viewer/pull/170 , plus some changes I made:
- fixed security issue by making content provider non-exported
- add a "Open with..." menu item, which is like Share but uses ACTION_VIEW. This gives me the option to open documents with other PDF viewers, whereas "Share" (ACTION_SEND) just has things like dropbox, gmail, etc.
