### PR TITLE
Update mupdf to 1.9a

### DIFF
--- a/document-viewer/jni/mupdf/Core.mk
+++ b/document-viewer/jni/mupdf/Core.mk
@@ -1,45 +1,83 @@
 LOCAL_PATH := $(call my-dir)
 
+ifdef SUPPORT_GPROOF
+include $(CLEAR_VARS)
+LOCAL_MODULE    := gsso
+LOCAL_SRC_FILES := libgs.so
+include $(PREBUILT_SHARED_LIBRARY)
+endif
+
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := mupdfcore
-LOCAL_SRC_FILES := \
-	$(subst $(LOCAL_PATH)/,, \
-	    $(wildcard $(LOCAL_PATH)/mupdf/source/fitz/*.c) \
-	    $(wildcard $(LOCAL_PATH)/mupdf/source/pdf/*.c) \
-	    $(wildcard $(LOCAL_PATH)/mupdf/source/xps/*.c) \
-	    $(wildcard $(LOCAL_PATH)/mupdf/source/cbz/*.c) \
-	    $(wildcard $(LOCAL_PATH)/mupdf/source/html/*.c) \
-    ) \
-	mupdf/source/pdf/js/pdf-js.c \
-	mupdf/source/pdf/js/pdf-jsimp-mu.c
-	
+MY_ROOT := $(LOCAL_PATH)/mupdf
+
+LOCAL_CFLAGS += -Wall -Wno-maybe-uninitialized
 LOCAL_CFLAGS += -DNOCJK
 
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DARCH_ARM -DARCH_THUMB -DARCH_ARM_CAN_LOAD_UNALIGNED
+ifdef NDK_PROFILER
+LOCAL_CFLAGS += -pg -DNDK_PROFILER
+endif
+endif
+ifdef SUPPORT_GPROOF
+LOCAL_CFLAGS += -DSUPPORT_GPROOF
 endif
 LOCAL_CFLAGS += -DAA_BITS=8
+ifdef MEMENTO
+LOCAL_CFLAGS += -DMEMENTO -DMEMENTO_LEAKONLY
+endif
+ifdef SSL_BUILD
+LOCAL_CFLAGS += -DHAVE_OPENSSL
+endif
 
 LOCAL_C_INCLUDES := \
-	$(LOCAL_PATH)/mupdf/thirdparty/jbig2dec \
-	$(LOCAL_PATH)/mupdf/thirdparty/openjpeg/libopenjpeg \
-	$(LOCAL_PATH)/mupdf/thirdparty/jpeg \
-	$(LOCAL_PATH)/mupdf/thirdparty/mujs \
-	$(LOCAL_PATH)/mupdf/thirdparty/zlib \
-	$(LOCAL_PATH)/mupdf/thirdparty/freetype/include \
-	$(LOCAL_PATH)/mupdf/source/fitz \
-	$(LOCAL_PATH)/mupdf/source/pdf \
-	$(LOCAL_PATH)/mupdf/source/xps \
-	$(LOCAL_PATH)/mupdf/source/cbz \
-	$(LOCAL_PATH)/mupdf/source/img \
-	$(LOCAL_PATH)/mupdf/source/tiff \
-	$(LOCAL_PATH)/mupdf/scripts/freetype \
-	$(LOCAL_PATH)/mupdf/scripts/jpeg \
-	$(LOCAL_PATH)/mupdf/scripts/openjpeg \
-	$(LOCAL_PATH)/mupdf/generated \
-	$(LOCAL_PATH)/mupdf/resources \
-	$(LOCAL_PATH)/mupdf/include \
-	$(LOCAL_PATH)/mupdf
+	$(MY_ROOT)/thirdparty/harfbuzz/src \
+	$(MY_ROOT)/thirdparty/jbig2dec \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg \
+	$(MY_ROOT)/thirdparty/jpeg \
+	$(MY_ROOT)/thirdparty/mujs \
+	$(MY_ROOT)/thirdparty/zlib \
+	$(MY_ROOT)/thirdparty/freetype/include \
+	$(MY_ROOT)/source/fitz \
+	$(MY_ROOT)/source/pdf \
+	$(MY_ROOT)/source/xps \
+	$(MY_ROOT)/source/cbz \
+	$(MY_ROOT)/source/img \
+	$(MY_ROOT)/source/tiff \
+	$(MY_ROOT)/scripts/freetype \
+	$(MY_ROOT)/scripts/jpeg \
+	$(MY_ROOT)/scripts/openjpeg \
+	$(MY_ROOT)/generated \
+	$(MY_ROOT)/resources \
+	$(MY_ROOT)/include \
+	$(MY_ROOT)
+ifdef V8_BUILD
+LOCAL_C_INCLUDES += $(MY_ROOT)/thirdparty/$(V8)/include
+endif
+ifdef SSL_BUILD
+LOCAL_C_INCLUDES += $(MY_ROOT)/thirdparty/openssl/include
+endif
+
+LOCAL_MODULE    := mupdfcore
+LOCAL_SRC_FILES := \
+	$(subst $(LOCAL_PATH)/,, \
+		$(wildcard $(MY_ROOT)/source/fitz/*.c) \
+		$(wildcard $(MY_ROOT)/source/pdf/*.c) \
+		$(wildcard $(MY_ROOT)/source/xps/*.c) \
+		$(wildcard $(MY_ROOT)/source/cbz/*.c) \
+		$(wildcard $(MY_ROOT)/source/gprf/*.c) \
+		$(wildcard $(MY_ROOT)/source/html/*.c) \
+		$(wildcard $(MY_ROOT)/generated/*.c) \
+	)
+LOCAL_SRC_FILES += \
+	mupdf/source/pdf/js/pdf-js.c \
+
+ifdef SUPPORT_GPROOF
+LOCAL_SHARED_LIBRARIES := gsso
+endif
+LOCAL_LDLIBS    := -lm -llog -ljnigraphics
+
+#LOCAL_SRC_FILES := $(addprefix ../, $(LOCAL_SRC_FILES))
 
 include $(BUILD_STATIC_LIBRARY)

--- a/document-viewer/jni/mupdf/Core.mk
+++ b/document-viewer/jni/mupdf/Core.mk
@@ -13,6 +13,8 @@ MY_ROOT := $(LOCAL_PATH)/mupdf
 
 LOCAL_CFLAGS += -Wall -Wno-maybe-uninitialized
 LOCAL_CFLAGS += -DNOCJK
+# Skip noto fonts to save space. see pdf-fontfile.c
+LOCAL_CFLAGS += -DTOFU
 
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DARCH_ARM -DARCH_THUMB -DARCH_ARM_CAN_LOAD_UNALIGNED

--- a/document-viewer/jni/mupdf/ThirdParty.mk
+++ b/document-viewer/jni/mupdf/ThirdParty.mk
@@ -2,128 +2,178 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := mupdfthirdparty
-LOCAL_SRC_FILES := \
-	mupdf/thirdparty/mujs/one.c \
-	mupdf/thirdparty/jbig2dec/jbig2.c \
-	mupdf/thirdparty/jbig2dec/jbig2_arith.c \
-	mupdf/thirdparty/jbig2dec/jbig2_arith_iaid.c \
-	mupdf/thirdparty/jbig2dec/jbig2_arith_int.c \
-	mupdf/thirdparty/jbig2dec/jbig2_generic.c \
-	mupdf/thirdparty/jbig2dec/jbig2_halftone.c \
-	mupdf/thirdparty/jbig2dec/jbig2_huffman.c \
-	mupdf/thirdparty/jbig2dec/jbig2_image.c \
-	mupdf/thirdparty/jbig2dec/jbig2_metadata.c \
-	mupdf/thirdparty/jbig2dec/jbig2_mmr.c \
-	mupdf/thirdparty/jbig2dec/jbig2_page.c \
-	mupdf/thirdparty/jbig2dec/jbig2_refinement.c \
-	mupdf/thirdparty/jbig2dec/jbig2_segment.c \
-	mupdf/thirdparty/jbig2dec/jbig2_symbol_dict.c \
-	mupdf/thirdparty/jbig2dec/jbig2_text.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/bio.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/cidx_manager.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/cio.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/dwt.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/event.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/function_list.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/image.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/invert.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/j2k.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/jp2.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/mct.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/mqc.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/openjpeg.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/opj_clock.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/phix_manager.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/pi.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/ppix_manager.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/raw.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/t1.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/t1_generate_luts.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/t2.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/tcd.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/tgt.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/thix_manager.c \
-	mupdf/thirdparty/openjpeg/libopenjpeg/tpix_manager.c \
-	mupdf/thirdparty/jpeg/jaricom.c \
-	mupdf/thirdparty/jpeg/jcomapi.c \
-	mupdf/thirdparty/jpeg/jdapimin.c \
-	mupdf/thirdparty/jpeg/jdapistd.c \
-	mupdf/thirdparty/jpeg/jdarith.c \
-	mupdf/thirdparty/jpeg/jdatadst.c \
-	mupdf/thirdparty/jpeg/jdatasrc.c \
-	mupdf/thirdparty/jpeg/jdcoefct.c \
-	mupdf/thirdparty/jpeg/jdcolor.c \
-	mupdf/thirdparty/jpeg/jddctmgr.c \
-	mupdf/thirdparty/jpeg/jdhuff.c \
-	mupdf/thirdparty/jpeg/jdinput.c \
-	mupdf/thirdparty/jpeg/jdmainct.c \
-	mupdf/thirdparty/jpeg/jdmarker.c \
-	mupdf/thirdparty/jpeg/jdmaster.c \
-	mupdf/thirdparty/jpeg/jdmerge.c \
-	mupdf/thirdparty/jpeg/jdpostct.c \
-	mupdf/thirdparty/jpeg/jdsample.c \
-	mupdf/thirdparty/jpeg/jdtrans.c \
-	mupdf/thirdparty/jpeg/jerror.c \
-	mupdf/thirdparty/jpeg/jfdctflt.c \
-	mupdf/thirdparty/jpeg/jfdctfst.c \
-	mupdf/thirdparty/jpeg/jfdctint.c \
-	mupdf/thirdparty/jpeg/jidctflt.c \
-	mupdf/thirdparty/jpeg/jidctfst.c \
-	mupdf/thirdparty/jpeg/jidctint.c \
-	mupdf/thirdparty/jpeg/jmemmgr.c \
-	mupdf/thirdparty/jpeg/jquant1.c \
-	mupdf/thirdparty/jpeg/jquant2.c \
-	mupdf/thirdparty/jpeg/jutils.c \
-	mupdf/thirdparty/zlib/adler32.c \
-	mupdf/thirdparty/zlib/compress.c \
-	mupdf/thirdparty/zlib/crc32.c \
-	mupdf/thirdparty/zlib/deflate.c \
-	mupdf/thirdparty/zlib/inffast.c \
-	mupdf/thirdparty/zlib/inflate.c \
-	mupdf/thirdparty/zlib/inftrees.c \
-	mupdf/thirdparty/zlib/trees.c \
-	mupdf/thirdparty/zlib/uncompr.c \
-	mupdf/thirdparty/zlib/zutil.c \
-	mupdf/thirdparty/freetype/src/base/ftbase.c \
-	mupdf/thirdparty/freetype/src/base/ftbbox.c \
-	mupdf/thirdparty/freetype/src/base/ftbitmap.c \
-	mupdf/thirdparty/freetype/src/base/ftgasp.c \
-	mupdf/thirdparty/freetype/src/base/ftglyph.c \
-	mupdf/thirdparty/freetype/src/base/ftinit.c \
-	mupdf/thirdparty/freetype/src/base/ftstroke.c \
-	mupdf/thirdparty/freetype/src/base/ftsynth.c \
-	mupdf/thirdparty/freetype/src/base/ftsystem.c \
-	mupdf/thirdparty/freetype/src/base/fttype1.c \
-	mupdf/thirdparty/freetype/src/base/ftxf86.c \
-	mupdf/thirdparty/freetype/src/cff/cff.c \
-	mupdf/thirdparty/freetype/src/cid/type1cid.c \
-	mupdf/thirdparty/freetype/src/psaux/psaux.c \
-	mupdf/thirdparty/freetype/src/pshinter/pshinter.c \
-	mupdf/thirdparty/freetype/src/psnames/psnames.c \
-	mupdf/thirdparty/freetype/src/raster/raster.c \
-	mupdf/thirdparty/freetype/src/smooth/smooth.c \
-	mupdf/thirdparty/freetype/src/sfnt/sfnt.c \
-	mupdf/thirdparty/freetype/src/truetype/truetype.c \
-	mupdf/thirdparty/freetype/src/type1/type1.c
+MY_ROOT := $(LOCAL_PATH)/mupdf
+
+LOCAL_C_INCLUDES := \
+	$(MY_ROOT)/include/ \
+	$(MY_ROOT)/thirdparty/harfbuzz/src \
+	$(MY_ROOT)/thirdparty/jbig2dec \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg \
+	$(MY_ROOT)/thirdparty/jpeg \
+	$(MY_ROOT)/thirdparty/mujs \
+	$(MY_ROOT)/thirdparty/zlib \
+	$(MY_ROOT)/thirdparty/freetype/include \
+	$(MY_ROOT)/scripts/freetype \
+	$(MY_ROOT)/scripts/jpeg \
+	$(MY_ROOT)/scripts/openjpeg
 
 LOCAL_CFLAGS := \
 	-DFT2_BUILD_LIBRARY -DDARWIN_NO_CARBON -DHAVE_STDINT_H \
 	-DOPJ_HAVE_STDINT_H \
 	'-DFT_CONFIG_MODULES_H="slimftmodules.h"' \
-	'-DFT_CONFIG_OPTIONS_H="slimftoptions.h"'
-	
-LOCAL_C_INCLUDES := \
-	$(LOCAL_PATH)/mupdf/thirdparty/jbig2dec \
-	$(LOCAL_PATH)/mupdf/thirdparty/openjpeg/libopenjpeg \
-	$(LOCAL_PATH)/mupdf/thirdparty/jpeg \
-	$(LOCAL_PATH)/mupdf/thirdparty/mujs \
-	$(LOCAL_PATH)/mupdf/thirdparty/zlib \
-	$(LOCAL_PATH)/mupdf/thirdparty/freetype/include \
-	$(LOCAL_PATH)/mupdf/thirdparty/freetype/include/freetype \
-	$(LOCAL_PATH)/mupdf/scripts/freetype \
-	$(LOCAL_PATH)/mupdf/scripts/jpeg \
-	$(LOCAL_PATH)/mupdf/scripts/openjpeg
+	'-DFT_CONFIG_OPTIONS_H="slimftoptions.h"' \
+	-Dhb_malloc_impl=hb_malloc -Dhb_calloc_impl=hb_calloc \
+	-Dhb_realloc_impl=hb_realloc -Dhb_free_impl=hb_free \
+	-DHAVE_OT -DHAVE_UCDN -DHB_NO_MT
+ifdef NDK_PROFILER
+LOCAL_CFLAGS += -pg -DNDK_PROFILER -O2
+endif
+ifdef MEMENTO
+LOCAL_CFLAGS += -DMEMENTO -DMEMENTO_LEAKONLY
+endif
+
+LOCAL_CPP_EXTENSION := .cc
+
+
+MY_ROOT := mupdf
+
+LOCAL_MODULE := mupdfthirdparty
+LOCAL_SRC_FILES := \
+	$(MY_ROOT)/thirdparty/mujs/one.c \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-blob.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-buffer.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-buffer-serialize.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-common.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-face.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-fallback-shape.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-font.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ft.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-font.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-layout.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-map.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-arabic.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-default.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-hangul.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-hebrew.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-indic-table.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-indic.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-myanmar.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-thai.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-tibetan.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-use-table.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-complex-use.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-fallback.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape-normalize.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-shape.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ot-tag.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-set.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-shape-plan.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-shape.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-shaper.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-ucdn.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-unicode.cc \
+	$(MY_ROOT)/thirdparty/harfbuzz/src/hb-warning.cc \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_arith.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_arith_iaid.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_arith_int.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_generic.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_halftone.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_huffman.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_image.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_metadata.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_mmr.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_page.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_refinement.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_segment.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_symbol_dict.c \
+	$(MY_ROOT)/thirdparty/jbig2dec/jbig2_text.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/bio.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/cidx_manager.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/cio.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/dwt.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/event.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/function_list.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/image.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/invert.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/j2k.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/jp2.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/mct.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/mqc.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/openjpeg.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/opj_clock.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/phix_manager.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/pi.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/ppix_manager.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/raw.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/t1.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/t1_generate_luts.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/t2.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/tcd.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/tgt.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/thix_manager.c \
+	$(MY_ROOT)/thirdparty/openjpeg/libopenjpeg/tpix_manager.c \
+	$(MY_ROOT)/thirdparty/jpeg/jaricom.c \
+	$(MY_ROOT)/thirdparty/jpeg/jcomapi.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdapimin.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdapistd.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdarith.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdatadst.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdatasrc.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdcoefct.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdcolor.c \
+	$(MY_ROOT)/thirdparty/jpeg/jddctmgr.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdhuff.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdinput.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdmainct.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdmarker.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdmaster.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdmerge.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdpostct.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdsample.c \
+	$(MY_ROOT)/thirdparty/jpeg/jdtrans.c \
+	$(MY_ROOT)/thirdparty/jpeg/jerror.c \
+	$(MY_ROOT)/thirdparty/jpeg/jfdctflt.c \
+	$(MY_ROOT)/thirdparty/jpeg/jfdctfst.c \
+	$(MY_ROOT)/thirdparty/jpeg/jfdctint.c \
+	$(MY_ROOT)/thirdparty/jpeg/jidctflt.c \
+	$(MY_ROOT)/thirdparty/jpeg/jidctfst.c \
+	$(MY_ROOT)/thirdparty/jpeg/jidctint.c \
+	$(MY_ROOT)/thirdparty/jpeg/jmemmgr.c \
+	$(MY_ROOT)/thirdparty/jpeg/jquant1.c \
+	$(MY_ROOT)/thirdparty/jpeg/jquant2.c \
+	$(MY_ROOT)/thirdparty/jpeg/jutils.c \
+	$(MY_ROOT)/thirdparty/zlib/adler32.c \
+	$(MY_ROOT)/thirdparty/zlib/compress.c \
+	$(MY_ROOT)/thirdparty/zlib/crc32.c \
+	$(MY_ROOT)/thirdparty/zlib/deflate.c \
+	$(MY_ROOT)/thirdparty/zlib/inffast.c \
+	$(MY_ROOT)/thirdparty/zlib/inflate.c \
+	$(MY_ROOT)/thirdparty/zlib/inftrees.c \
+	$(MY_ROOT)/thirdparty/zlib/trees.c \
+	$(MY_ROOT)/thirdparty/zlib/uncompr.c \
+	$(MY_ROOT)/thirdparty/zlib/zutil.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftbase.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftbbox.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftbitmap.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftfntfmt.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftgasp.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftglyph.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftinit.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftstroke.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftsynth.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/ftsystem.c \
+	$(MY_ROOT)/thirdparty/freetype/src/base/fttype1.c \
+	$(MY_ROOT)/thirdparty/freetype/src/cff/cff.c \
+	$(MY_ROOT)/thirdparty/freetype/src/cid/type1cid.c \
+	$(MY_ROOT)/thirdparty/freetype/src/psaux/psaux.c \
+	$(MY_ROOT)/thirdparty/freetype/src/pshinter/pshinter.c \
+	$(MY_ROOT)/thirdparty/freetype/src/psnames/psnames.c \
+	$(MY_ROOT)/thirdparty/freetype/src/raster/raster.c \
+	$(MY_ROOT)/thirdparty/freetype/src/smooth/smooth.c \
+	$(MY_ROOT)/thirdparty/freetype/src/sfnt/sfnt.c \
+	$(MY_ROOT)/thirdparty/freetype/src/truetype/truetype.c \
+	$(MY_ROOT)/thirdparty/freetype/src/type1/type1.c
 
 #LOCAL_SRC_FILES := $(addprefix ../, $(LOCAL_SRC_FILES))
 

--- a/document-viewer/jni/mupdf/overrides/nightmode_slowcmyk.patch
+++ b/document-viewer/jni/mupdf/overrides/nightmode_slowcmyk.patch
@@ -1,8 +1,8 @@
 diff --git a/include/mupdf/fitz/context.h b/include/mupdf/fitz/context.h
-index 10e28e0..f4368e7 100644
+index cb083f8..46d42dc 100644
 --- a/include/mupdf/fitz/context.h
 +++ b/include/mupdf/fitz/context.h
-@@ -111,6 +111,10 @@ struct fz_context_s
+@@ -113,6 +113,10 @@ struct fz_context_s
  	fz_store *store;
  	fz_glyph_cache *glyph_cache;
  	fz_document_handler_context *handler;
@@ -14,7 +14,7 @@ index 10e28e0..f4368e7 100644
  
  /*
 diff --git a/source/fitz/colorspace.c b/source/fitz/colorspace.c
-index d145be2..9329640 100644
+index 5549496..334c6f4 100644
 --- a/source/fitz/colorspace.c
 +++ b/source/fitz/colorspace.c
 @@ -1,6 +1,8 @@
@@ -56,7 +56,7 @@ index d145be2..9329640 100644
  }
  
  static void rgb_to_cmyk(fz_context *ctx, fz_colorspace *cs, const float *rgb, float *cmyk)
-@@ -619,7 +627,9 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -627,7 +635,9 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  
  	while (n--)
  	{
@@ -67,7 +67,7 @@ index d145be2..9329640 100644
  		unsigned int c = s[0];
  		unsigned int m = s[1];
  		unsigned int y = s[2];
-@@ -748,11 +758,15 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -756,11 +766,15 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  		d[0] = r;
  		d[1] = g;
  		d[2] = b;
@@ -85,7 +85,7 @@ index d145be2..9329640 100644
  		d[3] = s[4];
  		s += 5;
  		d += 4;
-@@ -767,7 +781,9 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -775,7 +789,9 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  	int n = src->w * src->h;
  	while (n--)
  	{
@@ -96,7 +96,7 @@ index d145be2..9329640 100644
  		float cmyk[4], rgb[3];
  		cmyk[0] = s[0] / 255.0f;
  		cmyk[1] = s[1] / 255.0f;
-@@ -777,11 +793,15 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
+@@ -785,11 +801,15 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src)
  		d[0] = rgb[2] * 255;
  		d[1] = rgb[1] * 255;
  		d[2] = rgb[0] * 255;
@@ -114,7 +114,7 @@ index d145be2..9329640 100644
  		d[3] = s[4];
  		s += 5;
  		d += 4;
-@@ -1090,29 +1110,41 @@ cmyk2g(fz_context *ctx, fz_color_converter *cc, float *dv, const float *sv)
+@@ -1098,29 +1118,41 @@ cmyk2g(fz_context *ctx, fz_color_converter *cc, float *dv, const float *sv)
  static void
  cmyk2rgb(fz_context *ctx, fz_color_converter *cc, float *dv, const float *sv)
  {
@@ -163,10 +163,10 @@ index d145be2..9329640 100644
  
  void fz_lookup_color_converter(fz_context *ctx, fz_color_converter *cc, fz_colorspace *ds, fz_colorspace *ss)
 diff --git a/source/fitz/draw-device.c b/source/fitz/draw-device.c
-index b2819a0..6a90da6 100644
+index fdb631f..ff0f143 100644
 --- a/source/fitz/draw-device.c
 +++ b/source/fitz/draw-device.c
-@@ -1201,6 +1201,9 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
+@@ -1203,6 +1203,9 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
  	fz_pixmap *scaled = NULL;
  	fz_pixmap *pixmap;
  	fz_pixmap *orig_pixmap;
@@ -176,11 +176,11 @@ index b2819a0..6a90da6 100644
  	int dx, dy;
  	int i;
  	fz_draw_state *state = &dev->stack[dev->top];
-@@ -1245,7 +1248,23 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
+@@ -1247,7 +1250,23 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
  			colorbv[i] = colorfv[i] * 255;
  		colorbv[i] = alpha * 255;
  
--		fz_paint_image_with_color(state->dest, &state->scissor, state->shape, pixmap, &local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES));
+-		fz_paint_image_with_color(state->dest, &state->scissor, state->shape, pixmap, &local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES), devp->flags & FZ_DEVFLAG_GRIDFIT_AS_TILED);
 +		// EBD: inverted mode >>>
 +		if (ctx->ebookdroid_nightmode) {
 +			inverted = fz_new_pixmap(ctx, pixmap->colorspace, pixmap->w, pixmap->h);
@@ -189,19 +189,19 @@ index b2819a0..6a90da6 100644
 +
 +			fz_paint_image_with_color(
 +				state->dest, &state->scissor, state->shape, inverted,
-+				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES)
++				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES), devp->flags & FZ_DEVFLAG_GRIDFIT_AS_TILED
 +			);
 +		} else {
 +			fz_paint_image_with_color(
 +				state->dest, &state->scissor, state->shape, pixmap,
-+				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES)
++				&local_ctm, colorbv, !(devp->hints & FZ_DONT_INTERPOLATE_IMAGES), devp->flags & FZ_DEVFLAG_GRIDFIT_AS_TILED
 +			);
 +		}
 +		// EBD: inverted mode <<<
  
  		if (scaled)
  			fz_drop_pixmap(ctx, scaled);
-@@ -1255,6 +1274,11 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
+@@ -1257,6 +1276,11 @@ fz_draw_fill_image_mask(fz_context *ctx, fz_device *devp, fz_image *image, const
  	}
  	fz_always(ctx)
  	{

--- a/init.sh
+++ b/init.sh
@@ -4,7 +4,7 @@ git submodule update --init --recursive --force
 
 cd document-viewer/jni/mupdf/mupdf
 make generate
-patch -p1 < ../overrides/fonts.patch
+#patch -p1 < ../overrides/fonts.patch
 patch -p1 < ../overrides/nightmode_slowcmyk.patch
 
 cd ../../djvu/djvulibre


### PR DESCRIPTION
- Disabled overrides/fonts.patch because it no longer applies cleanly due to refactoring in mupdf
- Core.mk and ThirdParty.mk update from mupdf repository. Paths tweaked to build in our repository, and restored the -DNOCJK flag we were using. Also added -DTOFU which disables more fonts that were added since mupdf 1.7.

Question: should the fonts.patch be restored?

I'm not sure what the original purpose of the patch was.
- If the idea is to substitute fonts in EPUB documents, we should see if there is a proper API in mupdf for this rather than maintaining this hacky patch.
- If the idea was to substitute fonts in PDF documents, this is wrong, afaik. Unless the idea was to compile mupdf without the PDF core fonts to save space, and then provide them from the DV font pack? Anyway, that seems too complex to maintain for a small space savings.