### PR TITLE
Integrate ACRA crash reporter, with a prompt to send an email.

### DIFF
--- a/document-viewer/build.gradle
+++ b/document-viewer/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 dependencies {
     compile 'jcifs:jcifs:1.3.17'
     compile 'com.android.support:support-v4:24.1.1'
+    compile 'ch.acra:acra:4.9.0'
 }
 
 import java.util.regex.Pattern

--- a/document-viewer/src/main/java/org/ebookdroid/EBookDroidApp.java
+++ b/document-viewer/src/main/java/org/ebookdroid/EBookDroidApp.java
@@ -1,5 +1,8 @@
 package org.ebookdroid;
 
+import org.acra.ACRA;
+import org.acra.ReportingInteractionMode;
+import org.acra.annotation.ReportsCrashes;
 import org.ebookdroid.common.bitmaps.BitmapManager;
 import org.ebookdroid.common.bitmaps.ByteBufferManager;
 import org.ebookdroid.common.cache.CacheManager;
@@ -27,6 +30,11 @@ import org.emdev.ui.gl.GLConfiguration;
 import org.emdev.utils.concurrent.Flag;
 import org.sufficientlysecure.viewer.R;
 
+@ReportsCrashes(mailTo = "fixme",
+        mode = ReportingInteractionMode.DIALOG,
+        resDialogCommentPrompt = R.string.crash_dialog_comment_prompt,
+        resDialogText = R.string.crash_dialog_text,
+        resDialogTitle = R.string.crash_dialog_title)
 public class EBookDroidApp extends BaseDroidApp implements IAppSettingsChangeListener, IBackupSettingsChangeListener,
         ILibSettingsChangeListener {
 
@@ -159,4 +167,11 @@ public class EBookDroidApp extends BaseDroidApp implements IAppSettingsChangeLis
         return null;
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+
+        // The following line triggers the initialization of ACRA
+        ACRA.init(this);
+    }
 }

--- a/document-viewer/src/main/res/values/strings_common.xml
+++ b/document-viewer/src/main/res/values/strings_common.xml
@@ -154,4 +154,10 @@
     <string name="cache_moving_progress">Moving cached files %1$d/%2$d</string>
 
     <string name="error_invalid_view_mode">This action is only available in view mode %1$s</string>
+
+    <string name="crash_dialog_title">Document Viewer has crashed</string>
+    <string name="crash_dialog_text">An unexpected error occurred
+            forcing the application to stop. Would you like to e-mail the
+            details to help fix the issue?</string>
+    <string name="crash_dialog_comment_prompt">You can add extra information and comments here:</string>
 </resources>


### PR DESCRIPTION
Adds a crash prompt that looks like this:
![screen](https://cloud.githubusercontent.com/assets/239161/18234577/d82bd694-72c7-11e6-8f13-9f8166528439.png)
If you click OK, it opens the email client.

I'm not sure where the emails should go. Probably should be a private mailing list, so users' email addresses aren't exposed on the web when they report a crash.

The data in the crash report is pretty minimal (phone model/brand/android version/app version/stack trace, plus user supplied comment)

Message strings are borrowed from fdroidclient.
If we go ahead with this, I should be able to copy all the translations from fdroidclient as well.