### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/document-viewer/src/main/java/org/ebookdroid/common/settings/books/DBAdapterV1.java
+++ b/document-viewer/src/main/java/org/ebookdroid/common/settings/books/DBAdapterV1.java
@@ -125,7 +125,10 @@ class DBAdapterV1 implements IDBAdapter {
                         if (c.moveToFirst()) {
                             final BookSettings bs = createBookSettings(c);
                             loadBookmarks(bs, db);
-                            return bs;
+                            if (c != null) {
+								c.close();
+							}
+							return bs;
                         }
                     } finally {
                         close(c);

--- a/document-viewer/src/main/java/org/ebookdroid/ui/viewer/views/BookmarkView.java
+++ b/document-viewer/src/main/java/org/ebookdroid/ui/viewer/views/BookmarkView.java
@@ -104,6 +104,9 @@ public class BookmarkView extends TextView {
             final MotionEvent cancel = MotionEvent.obtain(e);
             cancel.setAction(MotionEvent.ACTION_CANCEL);
             detector.onTouchEvent(cancel);
+			if (cancel != null) {
+				cancel.recycle();
+			}
         }
 
         /**

--- a/document-viewer/src/main/java/org/emdev/common/content/ContentScheme.java
+++ b/document-viewer/src/main/java/org/emdev/common/content/ContentScheme.java
@@ -45,6 +45,9 @@ public enum ContentScheme {
                     final String attachmentFileName = c.getString(fileNameColumnId);
                     return LengthUtils.safeString(attachmentFileName, key);
                 }
+				if (c != null) {
+					c.close();
+				}
             } catch (final Throwable th) {
                 th.printStackTrace();
             }

--- a/document-viewer/src/main/java/org/emdev/common/filesystem/PathFromUri.java
+++ b/document-viewer/src/main/java/org/emdev/common/filesystem/PathFromUri.java
@@ -12,8 +12,15 @@ public class PathFromUri {
         }
         final Cursor cursor = resolver.query(uri, new String[] { "_data" }, null, null, null);
         if ((cursor != null) && cursor.moveToFirst()) {
-            return cursor.getString(0);
+            final String returnValueAutoRefactor = cursor.getString(0);
+			if (cursor != null) {
+				cursor.close();
+			}
+			return returnValueAutoRefactor;
         }
+		if (cursor != null) {
+			cursor.close();
+		}
         throw new RuntimeException("Can't retrieve path from uri: " + uri.toString());
     }
 }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis