### PR TITLE
Fix Android 8 and above crash

### DIFF
--- a/document-viewer/src/main/res/values/service_preferences_performance.xml
+++ b/document-viewer/src/main/res/values/service_preferences_performance.xml
@@ -2,8 +2,8 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <string translatable="false" name="pref_pagesinmemory_id">pagesinmemory</string>
-    <string translatable="false" name="pref_pagesinmemory_defvalue">0</string>
-    <string translatable="false" name="pref_pagesinmemory_minvalue">0</string>
+    <string translatable="false" name="pref_pagesinmemory_defvalue">4</string>
+    <string translatable="false" name="pref_pagesinmemory_minvalue">1</string>
     <string translatable="false" name="pref_pagesinmemory_maxvalue">16</string>
 
     <string translatable="false" name="pref_decodethread_priority_id">decodethread_priority</string>


### PR DESCRIPTION
Crash resolved by making the default (performance -> pages in memory) setting anything larger than 0 (minimum=1 and default=4)

See:
https://github.com/SufficientlySecure/document-viewer/issues/299#issuecomment-512682996
https://github.com/SufficientlySecure/document-viewer/issues/302#issuecomment-512650844