### PR TITLE
Fix immersive mode for tablet

### DIFF
--- a/document-viewer/src/main/java/org/emdev/ui/uimanager/UIManager44x.java
+++ b/document-viewer/src/main/java/org/emdev/ui/uimanager/UIManager44x.java
@@ -29,7 +29,7 @@ public class UIManager44x extends UIManager40x {
 
     @Override
     protected int getHideSysUIFlags(final Activity activity) {
-        return isTabletUi(activity) ? STANDARD_SYS_UI_FLAGS : EXT_SYS_UI_FLAGS;
+        return EXT_SYS_UI_FLAGS;
     }
 
 }


### PR DESCRIPTION
Hey, after years! The only annoying thing for me now on a tablet, originally copied it from UIManager41x.java but it is really not needed I can say in a 10' or 7' tablet so lets always enable immersive mode no matter tablet or not. Thanks!