### PR TITLE
Update and complete Spanish translation

### DIFF
--- a/document-viewer/src/main/res/values-es/strings_actions.xml
+++ b/document-viewer/src/main/res/values-es/strings_actions.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="actions_verticalConfigScrollUp">"Desplazar hacia arriba"</string>
-    <string name="actions_verticalConfigScrollDown">"Desplazar hacia abajo"</string>
-    <string name="actions_quickZoom">"Ampliación rápida"</string>
-    <string name="actions_zoomToColumn">"Ampliar a columna"</string>
-    <string name="actions_leftTopCorner">"Desplazar hacia la esquina arriba a la izquierda"</string>
-    <string name="actions_rightTopCorner">"Desplazar hacia la esquina arriba a la derecha"</string>
-    <string name="actions_leftBottomCorner">"Desplazar hacia la esquina abajo a la izquierda"</string>
-    <string name="actions_rightBottomCorner">"Desplazar hacia la esquina abajo a la derecha"</string>
+    <string name="actions_verticalConfigScrollUp">Desplazar hacia arriba</string>>
+    <string name="actions_verticalConfigScrollDown">Desplazar hacia abajo</string>>
+    <string name="actions_quickZoom">Ampliación rápida</string>>
+    <string name="actions_zoomToColumn">Ampliar a columna</string>>
+    <string name="actions_leftTopCorner">Desplazar hacia la esquina arriba a la izquierda</string>>
+    <string name="actions_rightTopCorner">Desplazar hacia la esquina arriba a la derecha</string>>
+    <string name="actions_leftBottomCorner">Desplazar hacia la esquina abajo a la izquierda</string>>
+    <string name="actions_rightBottomCorner">Desplazar hacia la esquina abajo a la derecha</string>>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_bookmenu.xml
+++ b/document-viewer/src/main/res/values-es/strings_bookmenu.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="bookmenu_open">"Abrir libro en..."</string>
-    <string name="bookmenu_settings">"Mostrar configuraciones de libro"</string>
-    <string name="bookmenu_openbookshelf">"Mostrar estantería"</string>
-    <string name="bookmenu_openbookfolder">"Mostrar carpeta de libro"</string>
-    <string name="bookmenu_recentgroup">"Limpiar historial reciente…"</string>
-    <string name="bookmenu_removefromrecent">"Excluir de recientes"</string>
-    <string name="bookmenu_cleardata">"Limpiar datos de caché"</string>
-    <string name="bookmenu_deletesettings">"Eliminar configuraciones de libro"</string>
-    <string name="bookmenu_filegroup">"Operaciones con archivo"</string>
-    <string name="bookmenu_copy">"Copiar libro a…"</string>
-    <string name="bookmenu_rename">"Renombrar libro…"</string>
-    <string name="bookmenu_move">"Mover libro a…"</string>
-    <string name="bookmenu_delete">"Eliminar libro"</string>
+    <string name="bookmenu_open">Abrir libro en...</string>
+    <string name="bookmenu_settings">Mostrar configuraciones de libro</string>
+    <string name="bookmenu_openbookshelf">Mostrar estantería</string>
+    <string name="bookmenu_openbookfolder">Mostrar carpeta de libro</string>
+    <string name="bookmenu_recentgroup">Limpiar historial reciente…</string>
+    <string name="bookmenu_removefromrecent">Excluir de recientes</string>
+    <string name="bookmenu_cleardata">Limpiar datos de caché</string>
+    <string name="bookmenu_deletesettings">Eliminar configuraciones de libro</string>
+    <string name="bookmenu_filegroup">Operaciones con archivo</string>
+    <string name="bookmenu_copy">Copiar libro a…</string>
+    <string name="bookmenu_rename">Renombrar libro…</string>
+    <string name="bookmenu_move">Mover libro a…</string>
+    <string name="bookmenu_delete">Eliminar libro</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_common.xml
+++ b/document-viewer/src/main/res/values-es/strings_common.xml
@@ -1,124 +1,159 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="app_name">"Lector de documentos"</string>-->
-    <string name="confirmclose_title">"Cerrando visor…"</string>
-    <string name="confirmclose_msg">"¿Realmente quieres cerrar el visor?"</string>
-    <string name="confirmsave_msg">"¿Queréis almacenar este documento?"</string>
-    <string name="confirmsave_yes_btn">"Almacenar y cerrar"</string>
-    <string name="confirmsave_no_btn">"Cerrar"</string>-->
-    <string name="error_dlg_title">"Error en la aplicación"</string>
-    <string name="msg_bad_intent">"Intent o esquema erróneos:\n%s"</string>
-    <string name="msg_no_intent_data">"No hay datos en el Intent:\n%s"</string>
-    <string name="msg_unknown_intent_data_type">"Tipo de datos del Intent desconocidos:\n%s"</string>
-    <string name="msg_loading_book">"Cargando libro: %1$s…"</string>
-    <string name="msg_wrong_password">"Contraseña incorrecta…"</string>
-    <string name="msg_password_required">"Introduzca la contraseña…"</string>
-    <string name="msg_unexpected_error">"Sucedió un error inesperado:\n%s"</string>
-    <string name="msg_search_text_on_page">"Buscando en la página %1$d…"</string>
-    <string name="msg_no_text_found">"Texto no encontrado"</string>
-    <string name="dialog_title_goto_page">"Ir a Página"</string>
-    <string name="button_goto_page">"Ir a Página"</string>
-    <string name="text_page">"Página"</string>
-    <string name="error_close">"Cerrar"</string>
-    <string name="dialog_backup_name_hint">"Introduce nombre para nueva copia de seguridad…"</string>
-    <string name="dialog_backup_backup">"Copia de seguridad"</string>
-    <string name="dialog_backup_restore">"Restaurar"</string>
-    <string name="dialog_backup_remove">"Eliminar…"</string>
-    <string name="add_bookmark_name">"Introduzca una descripción para el marcador"</string>
-    <string name="bookmark_start">"Inicio"</string>
-    <string name="bookmark_current">"Posición actual"</string>
-    <string name="bookmark_end">"Fin"</string>
-    <string name="bookmark_invalid_page">"Número de página inválido. Rango: %1$d-%2$d"</string>
-    <string name="bookmarks_title">"Marcadores"</string>
-    <string name="clear_bookmarks_title">"Eliminar los marcadores"</string>
-    <string name="clear_bookmarks_text">"¿Está seguro de querer eliminar todos los marcadores?"</string>
-    <string name="del_bookmark_title">"Eliminar marcador"</string>
-    <string name="del_bookmark_text">"¿Está seguro de querer eliminar este marcador?"</string>
-    <string name="clear_recent_title">"Borrar historial reciente"</string>
-    <string name="clear_recent_text">"¿Está seguro de querer borrar la lista de los libros recientes?"</string>
-    <string name="bookcase_shelves">"Estanterías"</string>
-    <string name="recent_title">"Libros recientes"</string>
-    <string name="list_clear_recent_mode_clear_recent_list">"Borrar la lista de recientes"</string>
-    <string name="list_clear_recent_mode_delete_bookmarks">"Eliminar todos los marcadores"</string>
-    <string name="list_clear_recent_mode_delete_book_settings">"Eliminar todos los ajustes de los libros"</string>
-    <string name="list_clear_recent_mode_delete_cached_data">"Eliminar todos los archivos almacenados en caché"</string>
-    <string name="about_prefix">"es"</string>
-    <string name="about_title">"Acerca del programa"</string>
-    <string name="about_commmon_title">"Información general"</string>
-    <string name="about_fonts_title">"Fuentes"</string>
-    <string name="about_license_title">"Licencia"</string>
-    <string name="about_3dparty_title">"Software de terceros"</string>
-    <string name="about_changelog_title">"Modificaciones"</string>
-    <string name="about_thanks_title">"Agradecimientos"</string>
-    <string name="about_donations">"Donativos"</string>-->
-    <string name="opds">"Navegador OPDS"</string>
-    <string name="menu_opds">"Navegador OPDS"</string>
-    <string name="opds_connecting">"Conectando…"</string>
-    <string name="opds_loading_catalog">"Cargando catálogo"</string>
-    <string name="opds_loading_book">"Cargando libro: %1$s/%2$s…"</string>
-    <string name="opds_unpacking_book">"Desempaquetando libro: %1$s/%2$s…"</string>
-    <string name="opds_download_complete">"Descarga del libro completa: %s"</string>
-    <string name="opds_download_error">"Descarga del libro fallida: %s"</string>
-    <string name="opds_add_new_feed">"Añadir nuevo feed"</string>
-    <string name="opds_addfeed_title">"Añadiendo nuevo catalogo"</string>
-    <string name="opds_addfeed_msg">"Introduce un alias y una URL para el catálogo"</string>
-    <string name="opds_addfeed_ok">"Añadir"</string>
-    <string name="opds_addfeed_alias" translatable="true">"Alias:"</string>
-    <string name="opds_addfeed_url" translatable="true">"URL:"</string>
-    <string name="opds_addfeed_auth">"Se requiere autorización"</string>
-    <string name="opds_editfeed_title">"Editar catálogo"</string>
-    <string name="opds_editfeed_msg">"Introducir alias y URL para el catálogo"</string>
-    <string name="opds_editfeed_ok">"Guardar"</string>
-    <string name="opds_deletefeed_title">"Eliminar catálogo"</string>
-    <string name="opds_deletefeed_msg">"¿Realmente deseas eliminar el catálogo?"</string>
-    <string name="opds_deletefeed_ok">"Eliminar"</string>
-    <string name="opds_authfeed_title">"Autorización"</string>
-    <string name="opds_authfeed_msg">"Introduce usuario y contraseña para el catálogo"</string>
-    <string name="opds_authfeed_username">"Usuario:"</string>
-    <string name="opds_authfeed_password">"Contraseña:"</string>
-    <string name="opds_authfeed_ok">"Acceso"</string>
-    <string name="opds_error_title">"Error OPDS"</string>
-    <string name="opds_error_msg" translatable="true">"%s"</string>
-    <string name="opds_retry_download">"Reintentar"</string>
-    <string name="book_copy_start">"Copiando libro"</string>
-    <string name="book_copy_progress">"Copiando libro: %1$s/%2$s…"</string>
-    <string name="book_copy_complete">"Copia del libro completa: %s"</string>
-    <string name="book_copy_error">"Copia de libro fallida: %s"</string>
-    <string name="book_move_start">"Moviendo libro…"</string>
-    <string name="book_move_progress">"Moviendo libro: %1$s/%2$s…"</string>
-    <string name="book_move_complete">"Mover libro completado: %s"</string>
-    <string name="book_move_error">"Fallo al mover el libro: %s"</string>
-    <string name="book_rename_title">"Renombrar libro"</string>
-    <string name="book_rename_msg">"Introduce nuevo nombre para el libro:"</string>
-    <string name="book_delete_title">"Borrar libro"</string>
-    <string name="book_delete_msg">"¿Estás seguro de que quieres borrar este libro?"</string>
-    <string name="outline_title">"Índice"</string>
-    <string name="outline_missed">"No existe índice"</string>
-    <string name="error_page_out_of_rande">"Número de página inválido. Rango: 1-%1$d"</string>
-    <string name="msg_loading">"Cargando… Espere por favor"</string>
-    <string name="msg_getting_page_size">"Obteniendo tamaño de página %1$d/%2$d"</string>
-    <string name="tap_zones_single_tap">"Toque simple"</string>
-    <string name="tap_zones_double_tap">"Toque doble"</string>
-    <string name="tap_zones_long_tap">"Toque largo"</string>
-    <string name="tap_zones_two_finger_tap">"Toque con dos dedos"</string>
-    <string name="tap_zones_reset">"Reiniciar"</string>
-    <string name="tap_zones_delete">"Borrar"</string>
-    <string name="tap_zones_clear">"Limpiar"</string>
-    <string name="search_results_title">"Resultado de la búsqueda"</string>
-    <string name="search_book_dlg_title">"Buscar…"</string>
-    <string name="folder_books_count">"Libros: %1$d"</string>
-    <string name="copy_book_to_dlg_title">"Copiar libro a…"</string>
-    <string name="move_book_to_dlg_title">"Mover libro a…"</string>
-    <string name="opds_downloading_type_dlg_title">"Selecciona el tipo de libro para descargar"</string>
-    <string name="opds_downloading_dlg_title">"Descargando libro como…"</string>
-    <string name="opds_downloading_dlg_raw_type">"Tipo Raw"</string>
-    <string name="notification_file_add">"Archivo añadido a la biblioteca"</string>
-    <string name="notification_file_delete">"Archivo eliminado de la biblioteca"</string>
-    <string name="font_reminder_title">"Atención"</string>
-    <string name="font_reminder">"A partir de la versión 1.5, las fuentes de PDF y FB2 ya no están incluidas en la aplicación. Se usarán las fuentes estándar del sistema. Si quieres restablecer las fuentes antiguas o instalar otras, utiliza por favor los paquetes de instalación de fuentes de la Play Store: &lt;ul&gt;&lt;li&gt;&lt;a href=&quot;market://details?id=org.ebookdroid.fontpack.legacy&quot;&gt;Fuentes antiguas&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;"</string>
-    <string name="cache_moving_text">"Moviendo los archivos en memoria…"</string>
-    <string name="cache_moving_progress">"Moviendo los archivos en memoria %1$d/%2$d"</string>
-    <string name="error_invalid_view_mode">"Esta acción solamente está disponible en el modo de vista %1$s"</string>
+    <string name="app_name">Lector de documentos<string>
 
+    <string name="confirmclose_title">Cerrando visor…</string>
+    <string name="confirmclose_msg">¿Realmente quieres cerrar el visor?</string>
+    <string name="confirmsave_msg">¿Queréis almacenar este documento?</string>
+    <string name="confirmsave_yes_btn">Almacenar y cerrar</string>
+    <string name="confirmsave_no_btn">Cerrar<string>
+
+    <string name="error_dlg_title">Error en la aplicación</string>
+    <string name="msg_bad_intent">Intent o esquema erróneos:\n%s</string>
+    <string name="msg_no_intent_data">No hay datos en el Intent:\n%s</string>
+    <string name="msg_unknown_intent_data_type">Tipo de datos del Intent desconocidos:\n%s</string>
+
+    <string name="msg_loading_book">Cargando libro: %1$s…</string>
+
+    <string name="msg_wrong_password">Contraseña incorrecta…</string>
+    <string name="msg_password_required">Introduzca la contraseña…</string>
+
+    <string name="msg_unexpected_error">Sucedió un error inesperado:\n%s</string>
+
+    <string name="msg_search_text_on_page">Buscando en la página %1$d…</string>
+    <string name="msg_no_text_found">Texto no encontrado</string>
+
+    <string name="dialog_title_goto_page">Ir a Página</string>
+    <string name="button_goto_page">Ir a Página</string>
+    <string name="text_page">Página</string>
+    <string name="error_close">Cerrar</string>
+
+    <string name="dialog_backup_name_hint">Introduce nombre para nueva copia de seguridad…</string>
+    <string name="dialog_backup_backup">Copia de seguridad</string>
+    <string name="dialog_backup_restore">Restaurar</string>
+    <string name="dialog_backup_remove">Eliminar…</string>
+
+    <string name="add_bookmark_name">Introduzca una descripción para el marcador</string>
+    <string name="bookmark_start">Inicio</string>
+    <string name="bookmark_current">Posición actual</string>
+    <string name="bookmark_end">Fin</string>
+    <string name="bookmark_invalid_page">Número de página inválido. Rango: %1$d-%2$d</string>
+
+    <string name="bookmarks_title">Marcadores</string>
+    <string name="clear_bookmarks_title">Eliminar los marcadores</string>
+    <string name="clear_bookmarks_text">¿Está seguro de querer eliminar todos los marcadores?</string>
+
+    <string name="del_bookmark_title">Eliminar marcador</string>
+    <string name="del_bookmark_text">¿Está seguro de querer eliminar este marcador?</string>
+
+    <string name="clear_recent_title">Borrar historial reciente</string>
+    <string name="clear_recent_text">¿Está seguro de querer borrar la lista de los libros recientes?</string>
+
+    <string name="bookcase_shelves">Estanterías</string>
+    <string name="recent_title">Libros recientes</string>
+
+    <string name="list_clear_recent_mode_clear_recent_list">Borrar la lista de recientes</string>
+    <string name="list_clear_recent_mode_delete_bookmarks">Eliminar todos los marcadores</string>
+    <string name="list_clear_recent_mode_delete_book_settings">Eliminar todos los ajustes de los libros</string>
+    <string name="list_clear_recent_mode_delete_cached_data">Eliminar todos los archivos almacenados en caché</string>
+
+    <string name="about_prefix">es</string>
+    <string name="about_title">Acerca del programa</string>
+    <string name="about_commmon_title">Información general</string>
+    <string name="about_fonts_title">Fuentes</string>
+    <string name="about_license_title">Licencia</string>
+    <string name="about_3dparty_title">Software de terceros</string>
+    <string name="about_changelog_title">Modificaciones</string>
+    <string name="about_thanks_title">Agradecimientos</string>
+    <string name="about_donations">Donativos<string>
+
+    <string name="opds">Navegador OPDS</string>
+    <string name="menu_opds">Navegador OPDS</string>
+
+    <string name="opds_connecting">Conectando…</string>
+    <string name="opds_loading_catalog">Cargando catálogo</string>
+    <string name="opds_loading_book">Cargando libro: %1$s/%2$s…</string>
+    <string name="opds_unpacking_book">Desempaquetando libro: %1$s/%2$s…</string>
+
+    <string name="opds_download_complete">Descarga del libro completa: %s</string>
+    <string name="opds_download_error">Descarga del libro fallida: %s</string>
+
+    <string name="opds_add_new_feed">Añadir nuevo feed</string>
+    <string name="opds_addfeed_title">Añadiendo nuevo catalogo</string>
+    <string name="opds_addfeed_msg">Introduce un alias y una URL para el catálogo</string>
+    <string name="opds_addfeed_ok">Añadir</string>
+    <string name="opds_addfeed_alias" translatable="true">Alias:</string>
+    <string name="opds_addfeed_url" translatable="true">URL:</string>
+    <string name="opds_addfeed_auth">Se requiere autorización</string>
+    <string name="opds_editfeed_title">Editar catálogo</string>
+    <string name="opds_editfeed_msg">Introducir alias y URL para el catálogo</string>
+    <string name="opds_editfeed_ok">Guardar</string>
+    <string name="opds_deletefeed_title">Eliminar catálogo</string>
+    <string name="opds_deletefeed_msg">¿Realmente deseas eliminar el catálogo?</string>
+    <string name="opds_deletefeed_ok">Eliminar</string>
+    <string name="opds_authfeed_title">Autorización</string>
+    <string name="opds_authfeed_msg">Introduce usuario y contraseña para el catálogo</string>
+    <string name="opds_authfeed_username">Usuario:</string>
+    <string name="opds_authfeed_password">Contraseña:</string>
+    <string name="opds_authfeed_ok">Acceso</string>
+    <string name="opds_error_title">Error OPDS</string>
+    <string name="opds_error_msg" translatable="true">%s</string>
+    <string name="opds_retry_download">Reintentar</string>
+
+    <string name="book_copy_start">Copiando libro</string>
+    <string name="book_copy_progress">Copiando libro: %1$s/%2$s…</string>
+    <string name="book_copy_complete">Copia del libro completa: %s</string>
+    <string name="book_copy_error">Copia de libro fallida: %s</string>
+
+    <string name="book_move_start">Moviendo libro…</string>
+    <string name="book_move_progress">Moviendo libro: %1$s/%2$s…</string>
+    <string name="book_move_complete">Mover libro completado: %s</string>
+    <string name="book_move_error">Fallo al mover el libro: %s</string>
+
+    <string name="book_rename_title">Renombrar libro</string>
+    <string name="book_rename_msg">Introduce nuevo nombre para el libro:</string>
+
+    <string name="book_delete_title">Borrar libro</string>
+    <string name="book_delete_msg">¿Estás seguro de que quieres borrar este libro?</string>
+
+    <string name="outline_title">Índice</string>
+    <string name="outline_missed">No existe índice</string>
+
+    <string name="error_page_out_of_rande">Número de página inválido. Rango: 1-%1$d</string>
+
+    <string name="msg_loading">Cargando… Espere por favor</string>
+    <string name="msg_getting_page_size">Obteniendo tamaño de página %1$d/%2$d</string>
+
+    <string name="tap_zones_single_tap">Toque simple</string>
+    <string name="tap_zones_double_tap">Toque doble</string>
+    <string name="tap_zones_long_tap">Toque largo</string>
+    <string name="tap_zones_two_finger_tap">Toque con dos dedos</string>
+    <string name="tap_zones_reset">Reiniciar</string>
+    <string name="tap_zones_delete">Borrar</string>
+    <string name="tap_zones_clear">Limpiar</string>
+
+    <string name="search_results_title">Resultado de la búsqueda</string>
+    <string name="search_book_dlg_title">Buscar…</string>
+
+    <string name="folder_books_count">Libros: %1$d</string>
+    <string name="copy_book_to_dlg_title">Copiar libro a…</string>
+    <string name="move_book_to_dlg_title">Mover libro a…</string>
+
+    <string name="opds_downloading_type_dlg_title">Selecciona el tipo de libro para descargar</string>
+    <string name="opds_downloading_dlg_title">Descargando libro como…</string>
+    <string name="opds_downloading_dlg_raw_type">Tipo Raw</string>
+
+    <string name="notification_file_add">Archivo añadido a la biblioteca</string>
+    <string name="notification_file_delete">Archivo eliminado de la biblioteca</string>
+
+    <string name="font_reminder_title">Atención</string>
+    <string name="font_reminder">A partir de la versión 1.5, las fuentes de PDF y FB2 ya no están incluidas en la aplicación. Se usarán las fuentes estándar del sistema. Si quieres restablecer las fuentes antiguas o instalar otras, utiliza por favor los paquetes de instalación de fuentes de la Play Store: &lt;ul&gt;&lt;li&gt;&lt;a href=&quot;market://details?id=org.ebookdroid.fontpack.legacy&quot;&gt;Fuentes antiguas&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</string>
+
+    <string name="cache_moving_text">Moviendo los archivos en memoria…</string>
+    <string name="cache_moving_progress">Moviendo los archivos en memoria %1$d/%2$d</string>
+
+    <string name="error_invalid_view_mode">Esta acción solamente está disponible en el modo de vista %1$s</string>
+
+    <string name="error_write_external_storage_permission">Lector de documentos necesita el permiso WRITE_EXTERNAL_STORAGE</string>
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_mainmenu.xml
+++ b/document-viewer/src/main/res/values-es/strings_mainmenu.xml
@@ -1,35 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="menu_close">"Cerrar"</string>
-    <string name="menu_goto_page">"Ir a Página"</string>
-    <string name="menu_outline">"Sumario"</string>
-    <string name="menu_zoom">"Ampliar"</string>
-    <string name="menu_nightmode">"Día/Noche"</string>
-    <string name="menu_settings">"Todos los ajustes"</string>
-    <string name="menu_booksettings">"Configuración del libro"</string>
-    <string name="menu_cleanrecent">"Borrar los datos"</string>
-    <string name="menu_add_bookmark">"Añadir marcador"</string>
-    <string name="menu_edit_bookmark">"Modificar marcador"</string>
-    <string name="menu_thumbnail">"Colocar como miniatura"</string>
-    <string name="menu_about">"Acerca de"</string>
-    <string name="menu_tap_configuration">"Configurar toque"</string>
-    <string name="menu_key_bindings">"Atajos de teclado"</string>
-    <string name="menu_searchbook">"Buscar"</string>
-    <string name="menu_searchtext">"Buscar"</string>
-    <string name="menu_show_options_menu">"Mostrar menú de opciones"</string>
-    <string name="menu_backupsettings">"Configuración de Copias de seguridad y Respaldo"</string>
-    <string name="menu_crop">"Ajuste manual"</string>
-    <string name="menu_navigation_menu">"Navegación..."</string>
-    <string name="menu_fastsettings_menu">"Ver..."</string>
-    <string name="menu_allsettings_menu">"Ajuster..."</string>
-    <string name="menu_show_library">"Mostrar la biblioteca"</string>-->
-    <string name="menu_show_recent">"Mostrar recientes"</string>
-    <string name="menu_storages">"Almcenamientos"</string>
-    <string name="menu_storages_filesystem">"Sistema de ficheros"</string>
-    <string name="menu_storages_external">"Tarjeta de memoria SD"</string>-->
-    <string name="menu_force_portrait">"Forzar retrato"</string>
-    <string name="menu_force_landscape">"Forzar apaisado"</string>
-    <string name="menu_show_files">"Show files"</string> <!-- needs_translation -->
-    <string name="menu_search">"Search"</string> <!-- needs_translation -->
+    <string name="menu_close">Cerrar</string>
+    <string name="menu_goto_page">Ir a página</string>
+    <string name="menu_outline">Sumario</string>
+    <string name="menu_zoom">Ampliar</string>
+    <string name="menu_nightmode">Día/Noche</string>
+    <string name="menu_settings">Todos los ajustes</string>
+    <string name="menu_booksettings">Ajustes del libro</string>
+    <string name="menu_cleanrecent">Borrar recientes</string>
+    <string name="menu_add_bookmark">Añadir marcador</string>
+    <string name="menu_edit_bookmark">Modificar marcador</string>
+    <string name="menu_thumbnail">Colocar como miniatura</string>
+    <string name="menu_about">Acerca de</string>
+    <string name="menu_tap_configuration">Configurar toque</string>
+    <string name="menu_key_bindings">Atajos de teclado</string>
+    <string name="menu_searchbook">Buscar libros</string>
+    <string name="menu_searchtext">Buscar texto</string>
+    <string name="menu_show_options_menu">Mostrar menú de opciones</string>
+    <string name="menu_backupsettings">Copia de seguridad y restauración</string>
+    <string name="menu_crop">Recorte manual</string>
+    <string name="menu_singlepage">Página única</string>
+    <string name="menu_search">Buscar</string>
+
+    <string name="menu_navigation_menu">Navegación…</string>
+    <string name="menu_fastsettings_menu">Ver…</string>
+    <string name="menu_allsettings_menu">Ajustes…</string>
+
+    <string name="menu_share">Compartir…</string>
+    <string name="menu_openwith">Abrir con…</string>
+
+    <string name="menu_show_library">Mostrar la biblioteca</string>
+    <string name="menu_show_recent">Mostrar recientes</string>
+    <string name="menu_storages">Almacenamiento</string>
+    <string name="menu_storages_filesystem">Sistema de archivos</string>
+    <string name="menu_storages_external">Tarjeta de memoria SD</string>
+    <string name="menu_show_files">Mostrar archivos</string>
+
+    <string name="menu_force_portrait">Forzar retrato</string>
+    <string name="menu_force_landscape">Forzar apaisado</string>
+    <string name="menu_reverse_orientation">Invertir la orientación</string>
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_manual_cropping.xml
+++ b/document-viewer/src/main/res/values-es/strings_manual_cropping.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="manual_cropping_title">"Ajustar opciones de recorte:"</string>
-    <string name="manual_cropping_current">"Recortar sólo la página actual"</string>
-    <string name="manual_cropping_even">"Recortas todas las páginas pares (impares)"</string>
-    <string name="manual_cropping_even_symm">"Recortar páginas pares e impares simétricamente"</string>
-    <string name="manual_cropping_all">"Recortar todas las páginas"</string>
-    <string name="manual_cropping_remove_current">"Eliminar los ajustes de recorte para la página(s) actual"</string>
-    <string name="manual_cropping_remove_all">"Eliminar todos los ajustes de recorte"</string>
-    <string name="manual_cropping_back">"Volver a la selección de área"</string>
+    <string name="manual_cropping_title">Ajustar opciones de recorte:</string>
+    <string name="manual_cropping_current">Recortar sólo la página actual</string>
+    <string name="manual_cropping_even">Recortar todas las páginas pares (impares)</string>
+    <string name="manual_cropping_even_symm">Recortar páginas pares e impares simétricamente</string>
+	<string name="manual_cropping_all">Recortar todas las páginas</string>
+    <string name="manual_cropping_remove_current">Eliminar los ajustes de recorte para la página(s) actual</string>
+    <string name="manual_cropping_remove_all">Eliminar todos los ajustes de recorte</string>
+    <string name="manual_cropping_back">Volver a la selección de área</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_opdsmenu.xml
+++ b/document-viewer/src/main/res/values-es/strings_opdsmenu.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="opdsupfolder">"Arriba"</string>
-    <string name="opdsrefreshfolder">"Refrescar"</string>
-    <string name="opdsprevfolder">"Sección anterior"</string>
-    <string name="opdsnextfolder">"Sección siguiente"</string>
-    <string name="opds_feed_add">"Añadir"</string>
-    <string name="opdsclose">"Cerrar"</string>
-    <string name="opds_book_download">"Descargar"</string>
-    <string name="opdsgoto">"Abrir"</string>
-    <string name="opds_feed_edit">"Modificar"</string>
-    <string name="opds_feed_delete">"Borrar"</string>
+    <string name="opdsupfolder">Arriba</string>
+    <string name="opdsrefreshfolder">Refrescar</string>
+    <string name="opdsprevfolder">Sección anterior</string>
+    <string name="opdsnextfolder">Sección siguiente</string>
+    <string name="opds_feed_add">Añadir</string>
+    <string name="opdsclose">Cerrar</string>
 
+    <string name="opds_book_download">Descargar</string>
+
+    <string name="opdsgoto">Abrir</string>
+
+    <string name="opds_feed_edit">Modificar</string>
+    <string name="opds_feed_delete">Borrar</string>
+    
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_backup.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_backup.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_backup_category">"Copia seguridad y restauración"</string>
-    <string name="pref_backup_category_summary">"Preferencias de Copia de seguridad y restauración"</string>
-    <string name="pref_backuponexit_title">"Copia de seguridad al salir"</string>
-    <string name="pref_backuponexit_summary">"Se realizará automáticamente una copia de seguridad de las preferencias al salir de la aplicación"</string>
-    <string name="pref_backuponbookclose_title">"Copia de seguridad al cerrar libro"</string>
-    <string name="pref_backuponbookclose_summary">"Se realizará una copia de seguridad de las preferencias al cerrar el libro"</string>
-    <string name="pref_maxnumberofautobackups_title">"Número de copias automáticas"</string>
-    <string name="pref_maxnumberofautobackups_summary">"Número máximo de copias de seguridad automáticas"</string>
-    <string name="pref_bookbackuptype_title">"Copia de los ajustes del libro"</string>
-    <string name="pref_bookbackuptype_summary">"Copia de los ajustes del libro"</string>
-    <string name="list_bookbackuptype_none">"Ninguno"</string>
-    <string name="list_bookbackuptype_recent">"Reciente"</string>
-    <string name="list_bookbackuptype_all">"Todo"</string>
+    <string name="pref_backup_category">Copia seguridad y restauración</string>
+    <string name="pref_backup_category_summary">Preferencias de Copia de seguridad y restauración</string>
+
+    <string name="pref_backuponexit_title">Copia de seguridad al salir</string>
+    <string name="pref_backuponexit_summary">Se realizará automáticamente una copia de seguridad de las preferencias al salir de la aplicación</string>
+
+    <string name="pref_backuponbookclose_title">Copia de seguridad al cerrar libro</string>
+    <string name="pref_backuponbookclose_summary">Se realizará una copia de seguridad de las preferencias al cerrar el libro</string>
+
+    <string name="pref_maxnumberofautobackups_title">Número de copias automáticas</string>
+    <string name="pref_maxnumberofautobackups_summary">Número máximo de copias de seguridad automáticas</string>
+
+    <string name="pref_bookbackuptype_title">Copia de los ajustes del libro</string>
+    <string name="pref_bookbackuptype_summary">Copia de los ajustes del libro</string>
+
+    <string name="list_bookbackuptype_none">Ninguno</string>
+    <string name="list_bookbackuptype_recent">Reciente</string>
+    <string name="list_bookbackuptype_all">Todo</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_browser.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_browser.xml
@@ -1,45 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_browser_category">"Ver archivos"</string>
-    <string name="pref_browser_category_summary">"Configuración de archivos y tipos compatibles"</string>
-    <string name="pref_usebookcase_title">"Usar la vista de biblioteca"</string>
-    <string name="pref_usebookcase_summary">"Usar cubiertas/portadas en biblioteca en lugar de listas"</string>
-    <string name="pref_brautoscandir_title">"Directorio con escaneo automático"</string>
-    <string name="pref_brautoscandir_summary">"Directorio para búsqueda automática de archivos"</string>
-    <string name="pref_autoscanremovable_title">"Auto-escanear extraíbles"</string>
-    <string name="pref_autoscanremovable_summary">"Búsqueda automática en medios extraíbles presentes"</string>
-    <string name="pref_showremovable_title">"Mostrar extraíbles"</string>
-    <string name="pref_showremovable_summary">"Mostrar medios extraíbles en el menu de almacenamiento"</string>
-    <string name="pref_showscanning_title">"Mostrar directorios escaneados"</string>
-    <string name="pref_showscanning_summary">"Mostrar directorios para búsqueda automática en el menu de almacenamiento"</string>-->
-    <string name="pref_shownotifications_title">"Mostrar notificaciónes"</string>
-    <string name="pref_shownotifications_summary">"Mostrar notificaciónes en cuanto a archivos añadidos/eliminados"</string>
-    <string name="pref_cachelocation_title">"Localización de la caché"</string>
-    <string name="pref_cachelocation_summary">"Localización del archivo de caché"</string>
-    <string name="list_cachelocation_system">"En System"</string>
-    <string name="list_cachelocation_custom">"En Sdcard"</string>
-    <string name="pref_brbrfiletypesscreen_title">"Tipos de Archivo"</string>
-    <string name="pref_brbrfiletypesscreen_summary">"Tipos de Archivo a mostrar en la biblioteca"</string>
-<!--<string name="pref_brfiletypedjvu_title">".djvu"</string>-->
-    <string name="pref_brfiletypedjvu_summary">"Mostrar los archivos DjVu"</string>
-<!--<string name="pref_brfiletypedjv_title">".djv"</string>-->
-    <string name="pref_brfiletypedjv_summary">"Mostrar los archivos DjVu"</string>
-<!--<string name="pref_brfiletypepdf_title">".pdf"</string>-->
-    <string name="pref_brfiletypepdf_summary">"Mostrar los archivos PDF"</string>
-<!--<string name="pref_brfiletypexps_title">".xps"</string>-->
-    <string name="pref_brfiletypexps_summary">"Mostrar los archivos XPS"</string>
-<!--<string name="pref_brfiletypeoxps_title">".oxps"</string>-->
-    <string name="pref_brfiletypeoxps_summary">"Mostrar los archivos OXPS"</string>
-<!--<string name="pref_brfiletypeepub_title">".epub"</string>-->
-    <string name="pref_brfiletypeepub_summary">"Mostrar los archivos EPUB"</string>
-<!--<string name="pref_brfiletypecbz_title">".cbz"</string>-->
-    <string name="pref_brfiletypecbz_summary">"Mostrar los archivos CBZ"</string>
-<!--<string name="pref_brfiletypecbr_title">".cbr"</string>-->
-    <string name="pref_brfiletypecbr_summary">"Mostrar los archivos CBR"</string>
-<!--<string name="pref_brfiletypefb2_title">".fb2"</string>-->
-    <string name="pref_brfiletypefb2_summary">"Mostrar los archivos FB2 "</string>
-<!--<string name="pref_brfiletypefb2.zip_title">".fb2.zip"</string>-->
-    <string name="pref_brfiletypefb2.zip_summary">"Mostrar los archivos FB2.ZIP"</string>
+    <string name="pref_browser_category">Ver archivos</string>
+    <string name="pref_browser_category_summary">Configuración de archivos y tipos compatibles</string>
+
+    <string name="pref_usebookcase_title">Usar la vista de biblioteca</string>
+    <string name="pref_usebookcase_summary">Usar cubiertas/portadas en lugar de listas</string>
+
+    <string name="pref_brautoscandir_title">Directorio con escaneo automático</string>
+    <string name="pref_brautoscandir_summary">Directorio para búsqueda automática de archivos</string>
+
+    <string name="pref_autoscanremovable_title">Auto-escanear extraíbles</string>
+    <string name="pref_autoscanremovable_summary">Búsqueda automática en medios extraíbles presentes</string>
+
+    <string name="pref_showremovable_title">Mostrar extraíbles</string>
+    <string name="pref_showremovable_summary">Mostrar medios extraíbles en el menu de almacenamiento</string>
+
+    <string name="pref_showscanning_title">Mostrar directorios escaneados</string>
+    <string name="pref_showscanning_summary">Mostrar directorios para búsqueda automática en el menu de almacenamiento<string>
+
+    <string name="pref_shownotifications_title">Mostrar notificaciones</string>
+    <string name="pref_shownotifications_summary">Mostrar notificaciónes acerca de archivos añadidos/eliminados</string>
+
+    <string name="pref_cachelocation_title">Localización de la caché</string>
+    <string name="pref_cachelocation_summary">Localización del archivo de caché</string>
+    <string name="list_cachelocation_system">En el sistema</string>
+    <string name="list_cachelocation_custom">En la tarjeta SD</string>
+
+    <string name="pref_brbrfiletypesscreen_title">Tipos de Archivo</string>
+    <string name="pref_brbrfiletypesscreen_summary">Tipos de Archivo a mostrar en la biblioteca</string>
+
+    <string name="pref_brfiletypedjvu_title">.djvu</string>
+    <string name="pref_brfiletypedjvu_summary">Mostrar los archivos DjVu</string>
+
+    <string name="pref_brfiletypedjv_title">.djv</string>
+    <string name="pref_brfiletypedjv_summary">Mostrar los archivos DjVu</string>
+
+    <string name="pref_brfiletypepdf_title">.pdf</string>
+    <string name="pref_brfiletypepdf_summary">Mostrar los archivos PDF</string>
+
+    <string name="pref_brfiletypexps_title">.xps</string>
+    <string name="pref_brfiletypexps_summary">Mostrar los archivos XPS</string>
+
+    <string name="pref_brfiletypeoxps_title">.oxps</string>
+    <string name="pref_brfiletypeoxps_summary">Mostrar los archivos OXPS</string>
+
+    <string name="pref_brfiletypeepub_title">.epub</string>
+    <string name="pref_brfiletypeepub_summary">Mostrar los archivos EPUB</string>
+
+    <string name="pref_brfiletypecbz_title">.cbz</string>
+    <string name="pref_brfiletypecbz_summary">Mostrar los archivos CBZ</string>
+
+    <string name="pref_brfiletypecbr_title">.cbr</string>
+    <string name="pref_brfiletypecbr_summary">Mostrar los archivos CBR</string>
+
+    <string name="pref_brfiletypefb2_title">.fb2</string>
+    <string name="pref_brfiletypefb2_summary">Mostrar los archivos FB2 </string>
+
+    <string name="pref_brfiletypefb2.zip_title">.fb2.zip</string>
+    <string name="pref_brfiletypefb2.zip_summary">Mostrar los archivos FB2.ZIP</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_navigation.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_navigation.xml
@@ -1,23 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_navigation_category">"Navegación e Historial"</string>-->
-    <string name="pref_navigation_category_summary">"Ajustes de navegación e historial"</string>
-    <string name="pref_showbookmarksmenu_summary">"Mostrar marcadores"</string>-->
-    <string name="pref_showbookmarksmenu_title">"Mostrar los marcadores en el menú de navegación"</string>
-    <string name="pref_link_highlight_summary">"Elige color para el resalte de los enlaces"</string>
-    <string name="pref_link_highlight_title">"Resaltar enlaces"</string>
-    <string name="pref_search_highlight_summary">"Seleccionar color para el resalte de los resultados de búsqueda"</string>
-    <string name="pref_search_highlight_title">"Resaltar resultados"</string>
-    <string name="pref_current_search_highlight_summary">"Selecciona el color para resaltar el actual resultado de búsqueda"</string>
-    <string name="pref_current_search_highlight_title">"Resaltar resultado actual"</string>
-    <string name="pref_storeGotoHistory_title">"Almacenar la página destino en el historial de navegación"</string>
-<!--<string name="pref_storeGotoHistory_summary">""</string>-->
-    <string name="pref_storeLinkGotoHistory_title">"Almacenar enlace destino en el historial de navegación"</string>
-<!--<string name="pref_storeLinkGotoHistory_summary">""</string>-->
-    <string name="pref_storeOutlineGotoHistory_title">"Almacenar enlace destino de una imagen en el historial de navegación"</string>
-<!--<string name="pref_storeOutlineGotoHistory_summary">""</string>-->
-    <string name="pref_storeSearchGotoHistory_title">"Almacenar la búsqueda destino en el historial de navegación"</string>
-<!--<string name="pref_storeSearchGotoHistory_summary">""</string>-->
+    <string name="pref_navigation_category">Navegación e Historial</string>
+    <string name="pref_navigation_category_summary">Ajustes de navegación e historial</string>
+
+    <string name="pref_showbookmarksmenu_summary">Mostrar marcadores</string>
+    <string name="pref_showbookmarksmenu_title">Mostrar los marcadores en el menú de navegación</string>
+
+    <string name="pref_link_highlight_summary">Elige color para resaltar los enlaces</string>
+    <string name="pref_link_highlight_title">Resaltar enlaces</string>
+
+    <string name="pref_search_highlight_summary">Seleccionar color para resaltar los resultados de búsqueda</string>
+    <string name="pref_search_highlight_title">Resaltar resultados</string>
+
+    <string name="pref_current_search_highlight_summary">Selecciona el color para resaltar el actual resultado de búsqueda</string>
+    <string name="pref_current_search_highlight_title">Resaltar resultado actual</string>
+
+    <string name="pref_storeGotoHistory_title">Almacenar la página destino en el historial de navegación</string>
+    <string name="pref_storeGotoHistory_summary"></string>
+
+    <string name="pref_storeLinkGotoHistory_title">Almacenar enlace destino en el historial de navegación</string>
+    <string name="pref_storeLinkGotoHistory_summary"></string>
+
+    <string name="pref_storeOutlineGotoHistory_title">Almacenar enlace destino de una imagen en el historial de navegación</string>
+    <string name="pref_storeOutlineGotoHistory_summary"></string>
+
+    <string name="pref_storeSearchGotoHistory_title">Almacenar la búsqueda destino en el historial de navegación</string>
+    <string name="pref_storeSearchGotoHistory_summary"></string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_opds.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_opds.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_opds_category">"Configuración de OPDS"</string>
-    <string name="pref_opds_category_summary">"Ajustes del Navegador OPDS"</string>
-    <string name="pref_opds_downloaddir_title">"Carpeta de descargas"</string>
-    <string name="pref_opds_downloaddir_summary">"Descargar a"</string>
-    <string name="pref_opds_filterbooktypes_title">"Filtrar formatos de libro"</string>
-    <string name="pref_opds_filterbooktypes_summary">"Filtrar formatos de libro no soportados"</string>
-    <string name="pref_opds_downloadarchives_title">"Descargar libros comprimidos"</string>
-    <string name="pref_opds_downloadarchives_summary">"Descargar libros comprimidos"</string>
-    <string name="pref_opds_unpackarchives_title">"Desempaquetar libros comprimidos"</string>
-    <string name="pref_opds_unpackarchives_summary">"Desempaquetar los libros comprimidos tras su descarga"</string>
-    <string name="pref_opds_deletearchives_title">"Eliminar libros comprimidos"</string>
-    <string name="pref_opds_deletearchives_summary">"Eliminar los libros comprimidos tras desempaquetar"</string>
+    <string name="pref_opds_category">Configuración de OPDS</string>
+    <string name="pref_opds_category_summary">Ajustes del Navegador OPDS</string>
+
+    <string name="pref_opds_downloaddir_title">Carpeta de descargas</string>
+    <string name="pref_opds_downloaddir_summary">Descargar a</string>
+
+    <string name="pref_opds_filterbooktypes_title">Filtrar formatos de libro</string>
+    <string name="pref_opds_filterbooktypes_summary">Filtrar formatos de libro no soportados</string>
+
+    <string name="pref_opds_downloadarchives_title">Descargar libros comprimidos</string>
+    <string name="pref_opds_downloadarchives_summary">Descargar libros comprimidos</string>
+
+    <string name="pref_opds_unpackarchives_title">Desempaquetar libros comprimidos</string>
+    <string name="pref_opds_unpackarchives_summary">Desempaquetar los libros comprimidos tras su descarga</string>
+
+    <string name="pref_opds_deletearchives_title">Eliminar libros comprimidos</string>
+    <string name="pref_opds_deletearchives_summary">Eliminar los libros comprimidos tras desempaquetar</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_performance.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_performance.xml
@@ -1,35 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_performance_category">"Ajustes de rendimiento"</string>
-    <string name="pref_performance_category_summary">"Mejorar el rendimiento ajustando determinados parámetros"</string>
-    <string name="pref_pagesinmemory_title">"Páginas en memoria"</string>
-    <string name="pref_pagesinmemory_summary">"Número de páginas a almacenar en memoria"</string>
-    <string name="pref_lowlevel_category">"Preferencias de bajo nivel"</string>
-    <string name="pref_lowlevel_category_summary">"Preferencias de bajo nivel para la aplicación (se aplican tras recargar el documento)"</string>
-    <string name="pref_decoding_threads_title">"Hilos para la decodificación"</string>
-    <string name="pref_decoding_threads_summary">"Número de hilos usados en el proceso de decodificación"</string>
-    <string name="pref_decodethread_priority_title">"Prioridad del hilo de decodificación"</string>
-    <string name="pref_decodethread_priority_summary">"Define la prioridad del hilo encargado de la decodificación"</string>
-    <string name="pref_drawthread_priority_title">"Prioridad del hilo de dibujo"</string>
-    <string name="pref_drawthread_priority_summary">"Define la prioridad del hilo encargado del dibujo en pantalla"</string>
-    <string name="list_thread_priority_lowest">"Baja"</string>
-    <string name="list_thread_priority_lower">"Debajo de lo normal"</string>
-    <string name="list_thread_priority_normal" translatable="true">"Normal"</string>
-    <string name="list_thread_priority_higher">"Arriba de lo normal"</string>
-    <string name="list_thread_priority_highest">"Alta"</string>
-    <string name="pref_decodingonscroll_title">"Decodificar durante desplazamiento"</string>-->
-    <string name="pref_decodingonscroll_summary">"Permitir la decodificación de páginas cuando este desplazando o hojeando en el documento."</string>
-    <string name="pref_bitmapsize_title">"Tamaño de la texturas"</string>
-    <string name="pref_bitmapsize_summary">"Define el tamaño de las texturas"</string>
-<!--<string name="list_bitmapsize_64">"64 * 64"</string>-->
-<!--<string name="list_bitmapsize_128">"128 * 128"</string>-->
-<!--<string name="list_bitmapsize_256">"256 * 256"</string>-->
-<!--<string name="list_bitmapsize_512">"512 * 512"</string>-->
-<!--<string name="list_bitmapsize_1024">"1024 * 1024"</string>-->
-    <string name="pref_heappreallocate_title">"Reserva de Heap"</string>
-    <string name="pref_heappreallocate_summary">"Tamaño en MB de la reserva de Heap durante el inicio de la aplicación"</string>
-    <string name="pref_pdfstoragesize_title">"Tamaño de almacenamiento interno de MuPDF"</string>
-    <string name="pref_pdfstoragesize_summary">"Tamaño en MB para el almacenamiento interno de MuPDF"</string>
+    <string name="pref_performance_category">Ajustes de rendimiento</string>
+    <string name="pref_performance_category_summary">Mejorar el rendimiento ajustando determinados parámetros</string>
+
+    <string name="pref_pagesinmemory_title">Páginas en memoria</string>
+    <string name="pref_pagesinmemory_summary">Número de páginas a almacenar en memoria</string>
+
+    <string name="pref_lowlevel_category">Preferencias de bajo nivel</string>
+    <string name="pref_lowlevel_category_summary">Preferencias de bajo nivel para la aplicación (se aplican tras recargar el documento)</string>
+
+    <string name="pref_decoding_threads_title">Hilos para la decodificación</string>
+    <string name="pref_decoding_threads_summary">Número de hilos usados en el proceso de decodificación</string>
+
+    <string name="pref_decodethread_priority_title">Prioridad del hilo de decodificación</string>
+    <string name="pref_decodethread_priority_summary">Define la prioridad del hilo encargado de la decodificación</string>
+
+    <string name="pref_drawthread_priority_title">Prioridad del hilo de dibujo</string>
+    <string name="pref_drawthread_priority_summary">Define la prioridad del hilo encargado del dibujo en pantalla</string>
+
+    <string name="list_thread_priority_lowest">La más baja</string>
+    <string name="list_thread_priority_lower">Más baja</string>
+    <string name="list_thread_priority_normal">Normal</string>
+    <string name="list_thread_priority_higher">Alta</string>
+    <string name="list_thread_priority_highest">La más alta</string>
+
+    <string name="pref_decodingonscroll_title">Decodificar durante desplazamiento<string>
+    <string name="pref_decodingonscroll_summary">Permitir la decodificación de páginas cuando este desplazando o hojeando en el documento.</string>
+
+    <string name="pref_bitmapsize_title">Tamaño de la texturas</string>
+    <string name="pref_bitmapsize_summary">Define el tamaño de las texturas</string>
+
+    <string name="list_bitmapsize_64">64 x 64<string>
+    <string name="list_bitmapsize_128">128 x 128<string>
+    <string name="list_bitmapsize_256">256 x 256<string>
+    <string name="list_bitmapsize_512">512 x 512<string>
+    <string name="list_bitmapsize_1024">1024 x 1024<string>
+
+    <string name="pref_heappreallocate_title">Reserva de Heap</string>
+    <string name="pref_heappreallocate_summary">Tamaño en megabytes de la reserva de Heap durante el inicio de la aplicación</string>
+
+    <string name="pref_pdfstoragesize_title">Tamaño de almacenamiento interno de MuPDF</string>
+    <string name="pref_pdfstoragesize_summary">Tamaño en megabytes para el almacenamiento interno de MuPDF</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_render.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_render.xml
@@ -1,67 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_rotation_title">"Modo de rotación"</string>
-    <string name="pref_rotation_summary">"Cómo actúa la rotación"</string>
-    <string name="list_rotation_unspecified">"Sin especificar"</string>
-    <string name="list_rotation_land">"Forzar apaisado"</string>
-    <string name="list_rotation_port">"Forzar retrato"</string>
-    <string name="list_rotation_user">"Usuario"</string>
-    <string name="list_rotation_behind">"Heredar del fondo"</string>-->
-    <string name="list_rotation_auto">"Automático"</string>
-    <string name="list_rotation_nosensor">"Pasar de sensores"</string>
-    <string name="list_rotation_sensor_landscape">"Sensor apaisado"</string>
-    <string name="list_rotation_sensor_portrait">"Sensor retrato"</string>
-    <string name="list_rotation_reverse_landscape">"Modo apaisado invertido"</string>
-    <string name="list_rotation_reverse_portrait">"Modo retrato invertido"</string>
-    <string name="list_rotation_full_sensor">"Sensor completo"</string>
-    <string name="pref_render_category">"Representación"</string>
-    <string name="pref_render_category_summary">"Configuración de la Representación"</string>
-    <string name="pref_book_category">"Configuración del libro"</string>
-    <string name="pref_book_category_summary">"Configuración para el libro actual"</string>
-    <string name="pref_firstpageoffset_title">"Distancia de primera página"</string>
-    <string name="pref_firstpageoffset_summary">"Indice de la primera página presentada al usuario"</string>-->
-    <string name="pref_splitpages_title">"Dividir páginas"</string>
-    <string name="pref_splitpages_summary">"Dividir páginas apaisadas en dos de tipo retrato"</string>
-    <string name="pref_splitpages_rtl_title">"Dividir páginas derecha-a-izquierda"</string>
-    <string name="pref_splitpages_rtl_summary">"Dividir páginas apaisadas con dirección derecha-a-izquierda en dos de tipo retrato"</string>
-    <string name="pref_croppages_title">"Recortar las páginas"</string>
-    <string name="pref_croppages_summary">"Recortar los márgenes de las páginas (experimental)"</string>
-    <string name="pref_viewmode_title">"Modo de visualizado"</string>
-    <string name="pref_viewmode_summary">"Cómo visualizar el paginado del documento"</string>
-    <string name="list_viewmode_vertical_scroll">"Desplazamiento vertical"</string>
-    <string name="list_viewmode_horizontal_scroll">"Desplazamiento horizontal"</string>
-    <string name="list_viewmode_single_page">"Página única"</string>
-    <string name="pref_singlepage_category">"Configuración de página única"</string>
-    <string name="pref_singlepage_category_summary">"Ajustes para el modo de página única"</string>
-    <string name="pref_align_title">"Modo de alineación de página"</string>
-    <string name="pref_align_summary">"Cómo alinear las páginas"</string>
-    <string name="list_align_by_width">"Según anchura"</string>
-    <string name="list_align_by_height">"Según altura"</string>
-    <string name="list_align_auto">"Automático"</string>
-    <string name="pref_animationtype_title">"Animación"</string>
-    <string name="pref_animationtype_summary">"Seleccione el tipo de animación para las transiciones"</string>
-    <string name="list_animation_none">"Ninguno"</string>
-    <string name="list_animation_curler_simple">"Transición simple"</string>
-    <string name="list_animation_curler_dynamic">"Transición dinámica"</string>
-    <string name="list_animation_curler_natural">"Transición natural"</string>
-    <string name="list_animation_slider">"Desplazamiento"</string>
-    <string name="list_animation_fader">"Fundido"</string>
-    <string name="list_animation_squeezer">"Compresión"</string>
-    <string name="list_animation_slider2">"Otro desplazamiento"</string>
-    <string name="pref_postprocessing_category">"Efectos post–proceso"</string>
-    <string name="pref_postprocessing_summary">"Efectos de post–procesado"</string>
-    <string name="pref_nightmode_title">"Modo nocturno"</string>
-    <string name="pref_nightmode_summary">"Letras blancas sobre fondo negro"</string>
-    <string name="pref_posimages_in_nightmode_title">"Imágenes positivas en modo nocturno"</string>
-    <string name="pref_posimages_in_nightmode_summary">"Mostrar las imágenes en escala de grises en modo nocturno (no invertir los colores de la imagen)"</string>
-    <string name="pref_contrast_title">"Contraste"</string>
-    <string name="pref_contrast_summary">"Nivel de corrección de contraste (0–1000, 100 por defecto)"</string>
-    <string name="pref_gamma_title">"Gamma"</string>
-    <string name="pref_gamma_summary">"Nivel de corrección de gamma (0–200, 100 por defecto)"</string>
-    <string name="pref_exposure_title">"Exposición"</string>
-    <string name="pref_exposure_summary">"Nivel de corrección de exposición (0–200, 100 por defecto)"</string>
-    <string name="pref_autolevels_title">"Auto ajustar niveles"</string>
-    <string name="pref_autolevels_summary">"Ajustar automáticamente los niveles de corrección"</string>
+    <string name="pref_rotation_title">Modo de rotación</string>
+    <string name="pref_rotation_summary">Cómo actúa la rotación</string>
 
+    <string name="list_rotation_unspecified">Sin especificar</string>
+    <string name="list_rotation_land">Forzar apaisado</string>
+    <string name="list_rotation_port">Forzar retrato</string>
+    <string name="list_rotation_user">Usuario</string>
+    <string name="list_rotation_behind">Heredar del fondo<string>
+    <string name="list_rotation_auto">Automático</string>
+    <string name="list_rotation_nosensor">Sin sensor</string>
+    <string name="list_rotation_sensor_landscape">Forzar apaisado pero sensor de inversión</string>
+    <string name="list_rotation_sensor_portrait">Forzar retrato pero sensor de inversión</string>
+    <string name="list_rotation_reverse_landscape">Modo apaisado invertido</string>
+    <string name="list_rotation_reverse_portrait">Modo retrato invertido</string>
+    <string name="list_rotation_full_sensor">Sensor completo</string>
+
+    <string name="pref_render_category">Representación</string>
+    <string name="pref_render_category_summary">Configuración de la Representación</string>
+
+    <string name="pref_book_category">Configuración del libro</string>
+    <string name="pref_book_category_summary">Configuración para el libro actual</string>
+
+    <string name="pref_firstpageoffset_title">Distancia de primera página</string>
+    <string name="pref_firstpageoffset_summary">Índice de la primera página presentada al usuario<string>
+
+    <string name="pref_splitpages_title">Dividir páginas</string>
+    <string name="pref_splitpages_summary">Dividir páginas apaisadas en dos de tipo retrato</string>
+
+    <string name="pref_splitpages_rtl_title">Dividir páginas derecha-a-izquierda</string>
+    <string name="pref_splitpages_rtl_summary">Dividir páginas apaisadas con dirección derecha-a-izquierda en dos de tipo retrato</string>
+
+    <string name="pref_croppages_title">Recortar las páginas</string>
+    <string name="pref_croppages_summary">Recortar los márgenes de las páginas para maximizar el contenido mostrado</string>
+
+    <string name="pref_viewmode_title">Modo de visualizado</string>
+    <string name="pref_viewmode_summary">Visualizar el documento como páginas únicas o como un desplazamiento continuo</string>
+
+    <string name="list_viewmode_vertical_scroll">Desplazamiento vertical</string>
+    <string name="list_viewmode_horizontal_scroll">Desplazamiento horizontal</string>
+    <string name="list_viewmode_single_page">Página única</string>
+
+    <string name="pref_singlepage_category">Configuración de página única</string>
+    <string name="pref_singlepage_category_summary">Ajustes para el modo de página única</string>
+
+    <string name="pref_align_title">Modo de alineación de página</string>
+    <string name="pref_align_summary">Cómo alinear las páginas</string>
+
+    <string name="list_align_by_width">Según anchura</string>
+    <string name="list_align_by_height">Según altura</string>
+    <string name="list_align_auto">Automático</string>
+
+    <string name="pref_animationtype_title">Transición de páginas</string>
+    <string name="pref_animationtype_summary">Seleccione la animación para las transiciones en el modo de página única</string>
+
+    <string name="list_animation_none">Ninguno</string>
+    <string name="list_animation_curler_simple">Transición simple</string>
+    <string name="list_animation_curler_dynamic">Transición dinámica</string>
+    <string name="list_animation_curler_natural">Transición natural</string>
+    <string name="list_animation_slider">Desplazamiento</string>
+    <string name="list_animation_fader">Fundido</string>
+    <string name="list_animation_squeezer">Compresión</string>
+    <string name="list_animation_slider2">Otro desplazamiento</string>
+
+    <string name="pref_postprocessing_category">Efectos post&#8211;proceso</string>
+    <string name="pref_postprocessing_summary">Efectos adicionales para mejorar la visualización de páginas</string>
+
+    <string name="pref_nightmode_title">Modo nocturno</string>
+    <string name="pref_nightmode_summary">Letras blancas sobre fondo negro (negativo de imagen)</string>
+
+    <string name="pref_posimages_in_nightmode_title">Imágenes positivas en modo nocturno</string>
+    <string name="pref_posimages_in_nightmode_summary">Mostrar las imágenes en escala de grises en modo nocturno (no invertir los colores de la imagen)</string>
+
+    <string name="pref_tint_title">Tinte</string>
+    <string name="pref_tint_summary">Teñir el color de la página usando el color especificado abajo</string>
+
+    <string name="pref_tint_color_title">Color del tinte</string>
+    <string name="pref_tint_color_summary">Color con el que teñir las páginas</string>
+
+    <string name="pref_contrast_title">Contraste</string>
+    <string name="pref_contrast_summary">Nivel de corrección de contraste (0 &#8211; 1000, 100 por defecto)</string>
+
+    <string name="pref_gamma_title">Gamma</string>
+    <string name="pref_gamma_summary">Nivel de corrección de gamma (0 &#8211; 200, 100 por defecto)</string>
+
+    <string name="pref_exposure_title">Exposición</string>
+    <string name="pref_exposure_summary">Nivel de corrección de exposición (0 &#8211; 200, 100 por defecto)</string>
+
+    <string name="pref_autolevels_title">Auto ajustar niveles</string>
+    <string name="pref_autolevels_summary">Ajustar automáticamente los niveles de corrección</string>
+
+    <string name="pref_rtl_title">Derecha-a-izquierda</string>
+    <string name="pref_rtl_summary">Orden de página para modos de desplazamiento horizontal y de página única</string>
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_scroll.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_scroll.xml
@@ -1,15 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_scroll_category">"Táctil y desplazamientos"</string>
-    <string name="pref_scroll_category_summary">"Configuración táctil y desplazamientos"</string>
-    <string name="pref_tapsenabled_title">"Habilitar toques"</string>
-    <string name="pref_tapsenabled_summary">"Utilice la configuración de toques para definir regiones y acciones"</string>
-    <string name="pref_scroll_title">"Longitud del desplazamiento"</string>
-    <string name="pref_scroll_summary">"Ajuste la longitud del desplazamiento"</string>
-    <string name="pref_touchdelay_title">"Demora al procesar toque"</string>
-    <string name="pref_touchdelay_summary">"Demora al procesar toque (en milisegundos)"</string>
-    <string name="pref_animate_scrolling_title">"Animar desplazamiento"</string>
-    <string name="pref_animate_scrolling_summary">"Animar desplazamiento durante los modos de desplazamiento"</string>
+    <string name="pref_scroll_category">Táctil y desplazamientos</string>
+    <string name="pref_scroll_category_summary">Configuración táctil y desplazamientos</string>
+
+    <string name="pref_tapsenabled_title">Habilitar toques</string>
+    <string name="pref_tapsenabled_summary">Utilice la configuración de toques para definir regiones y acciones</string>
+
+    <string name="pref_scroll_title">Longitud del desplazamiento</string>
+    <string name="pref_scroll_summary">Ajuste la longitud del desplazamiento</string>
+
+    <string name="pref_touchdelay_title">Demora al procesar toque</string>
+    <string name="pref_touchdelay_summary">Demora al procesar toque (en milisegundos)</string>
+
+    <string name="pref_animate_scrolling_title">Animar desplazamiento</string>
+    <string name="pref_animate_scrolling_summary">Animar desplazamiento durante los modos de desplazamiento</string>
+
+    <string name="pref_volumekeyscrolling_title">Desplazamiento con botones de volumen</string>
+    <string name="pref_volumekeyscrolling_summary">Usar los botones de volumen para el desplazamiento en lugar de para ajustar el volumen</string>
+
+    <string name="pref_tapfullscreen_title">Toque alterna pantalla completa</string>
+    <string name="pref_tapfullscreen_summary">Alternar pantalla completa con un toque en cualquier zona de toque o hiperenlace</string>
 
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_typespec.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_typespec.xml
@@ -1,57 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_brfiletypespecific_title">"Ajustes específicos"</string>
-    <string name="pref_brfiletypespecific_summary">"Ajustes específicos para cada formato"</string>
-<!--<string name="pref_brfiletypespecificdjvu_title">"DJVU"</string>-->
-    <string name="pref_brfiletypespecificdjvu_summary">"Ajustes para DJVU"</string>
-    <string name="pref_djvu_rendering_mode_title">"Modo de representación"</string>
-    <string name="pref_djvu_rendering_mode_summary">"Modo de representación de la página"</string>
-    <string name="list_djvu_rendering_mode_0" translatable="true">"Color"</string>
-    <string name="list_djvu_rendering_mode_1">"Blanco y Negro"</string>
-    <string name="list_djvu_rendering_mode_2">"Sólo el color"</string>
-    <string name="list_djvu_rendering_mode_3">"Sólo la máscara"</string>
-    <string name="list_djvu_rendering_mode_4">"Sólo la capa de fondo"</string>
-    <string name="list_djvu_rendering_mode_5">"Sólo la capa principal"</string>
-<!--<string name="pref_brfiletypespecificpdf_title">"PDF"</string>-->
-    <string name="pref_brfiletypespecificpdf_summary">"Opciones específicas para PDF"</string>
-    <string name="pref_customdpi_title">"Personalizar DPI"</string>
-    <string name="pref_customdpi_summary">"Definir los valores personalizados de DPI a continuación"</string>
-    <string name="pref_xdpi_title">"DPI en X"</string>
-    <string name="pref_xdpi_summary">"DPI Horizontal (dirección X)"</string>
-    <string name="pref_ydpi_title">"DPI en Y"</string>
-    <string name="pref_ydpi_summary">"DPI Vertical (dirección Y)"</string>
-    <string name="pref_monofontpack_title">"Fuentes Monospace"</string>
-    <string name="pref_monofontpack_summary">"Define el paquete de fuentes monospace a utilizar"</string>
-    <string name="pref_sansfontpack_title">"Fuentes Sans"</string>
-    <string name="pref_sansfontpack_summary">"Define el paquete de fuentes sans a utilizar"</string>
-    <string name="pref_seriffontpack_title">"Fuentes Serif"</string>
-    <string name="pref_seriffontpack_summary">"Define el paquete de fuentes serif a utilizar"</string>
-    <string name="pref_symbolfontpack_title">"Fuentes Symbol"</string>
-    <string name="pref_symbolfontpack_summary">"Define el paquete de fuentes symbol a utilizar"</string>
-    <string name="pref_dingbatfontpack_title">"Fuentes Dingbat"</string>
-    <string name="pref_dingbatfontpack_summary">"Define el paquete de fuentes dingbat a utilizar"</string>
-    <string name="pref_systemfontpack">"Fuentes Android por defecto"</string>
-    <string name="pref_slowcmyk_title">"CMYK lento"</string>
-    <string name="pref_slowcmyk_summary">"Emplear el algoritmo de conversión lento pero preciso CMYK a RGB"</string>
-<!--<string name="pref_brfiletypespecificfb2_title">"FB2"</string>-->
-    <string name="pref_brfiletypespecificfb2_summary">"Opciones específicas para FB2"</string>
-    <string name="pref_fb2_xmlparser_title">"Intérprete XML"</string>
-    <string name="pref_fb2_xmlparser_summary">"Intérprete XML"</string>
-    <string name="list_fb2_xmlparser_vtd_ex">"Basado en VTD"</string>
-    <string name="list_fb2_xmlparser_duckbill">"Tonto &amp; Sucio"</string>
-    <string name="pref_fontsize_title">"Tamaño de la fuente"</string>
-    <string name="pref_fontsize_summary">"Tamaño base de la fuente"</string>
-    <string name="pref_fb2fontpack_title">"Fuentes FB2"</string>
-    <string name="pref_fb2fontpack_summary">"Define el paquete de fuentes para el renderizado de FB2"</string>
-    <string name="list_fontsize_tiny">"Diminuta"</string>
-    <string name="list_fontsize_small">"Pequeña"</string>
-    <string name="list_fontsize_normal" translatable="true">"Normal"</string>
-    <string name="list_fontsize_large">"Grande"</string>
-    <string name="list_fontsize_huge">"Enorme"</string>
-    <string name="pref_fb2hyphen_title">"Habilitar separación silábica"</string>
-    <string name="pref_fb2hyphen_summary">"Activar el soporte experimental para la separación silábica"</string>
-    <string name="pref_fb2cacheimages_title">"Caché de imágenes"</string>
-    <string name="pref_fb2cacheimages_summary">"Almacenar temporalmente las images de los documentos en disco para reducir el consumo de memoria"</string>
+    <string name="pref_brfiletypespecific_title">Ajustes específicos</string>
+    <string name="pref_brfiletypespecific_summary">Ajustes específicos para cada formato</string>
 
+    <string name="pref_brfiletypespecificdjvu_title">DJVU<string>
+    <string name="pref_brfiletypespecificdjvu_summary">Ajustes para DJVU</string>
+
+    <string name="pref_djvu_rendering_mode_title">Modo de representación</string>
+    <string name="pref_djvu_rendering_mode_summary">Modo de representación de la página</string>
+
+    <string name="list_djvu_rendering_mode_0">Color</string>
+    <string name="list_djvu_rendering_mode_1">Blanco y Negro</string>
+    <string name="list_djvu_rendering_mode_2">Solo el color</string>
+    <string name="list_djvu_rendering_mode_3">Solo la máscara</string>
+    <string name="list_djvu_rendering_mode_4">Solo la capa de fondo</string>
+    <string name="list_djvu_rendering_mode_5">Solo la capa principal</string>
+
+    <string name="pref_brfiletypespecificpdf_title">PDF<string>
+    <string name="pref_brfiletypespecificpdf_summary">Opciones específicas para PDF</string>
+
+    <string name="pref_customdpi_title">Personalizar DPI</string>
+    <string name="pref_customdpi_summary">Definir los valores personalizados de DPI a continuación</string>
+
+    <string name="pref_xdpi_title">DPI en X</string>
+    <string name="pref_xdpi_summary">DPI Horizontal (dirección X)</string>
+
+    <string name="pref_ydpi_title">DPI en Y</string>
+    <string name="pref_ydpi_summary">DPI Vertical (dirección Y)</string>
+
+    <string name="pref_monofontpack_title">Tipos de letra de ancho fijo</string>
+    <string name="pref_monofontpack_summary">Define el paquete de tipos de letra de ancho fijo a utilizar</string>
+
+    <string name="pref_sansfontpack_title">Tipos de letra sin serif</string>
+    <string name="pref_sansfontpack_summary">Define el paquete de tipos de letra sin serif a utilizar</string>
+
+    <string name="pref_seriffontpack_title">Tipos de letra serif</string>
+    <string name="pref_seriffontpack_summary">Define el paquete de tipos de letra serif a utilizar</string>
+
+    <string name="pref_symbolfontpack_title">Tipos de letra de símbolos</string>
+    <string name="pref_symbolfontpack_summary">Define el paquete de tipos de letra de símbolos a utilizar</string>
+
+    <string name="pref_dingbatfontpack_title">Fuentes Dingbat</string>
+    <string name="pref_dingbatfontpack_summary">Define el paquete de fuentes dingbat a utilizar</string>
+
+    <string name="pref_systemfontpack">Tipos de letra de Android por defecto</string>
+
+    <string name="pref_slowcmyk_title">CMYK lento</string>
+    <string name="pref_slowcmyk_summary">Emplear el algoritmo de conversión lento pero preciso CMYK a RGB</string>
+
+    <string name="pref_brfiletypespecificfb2_title">FB2<string>
+    <string name="pref_brfiletypespecificfb2_summary">Opciones específicas para FB2</string>
+
+    <string name="pref_fb2_xmlparser_title">Intérprete XML</string>
+    <string name="pref_fb2_xmlparser_summary">Intérprete XML</string>
+
+    <string name="list_fb2_xmlparser_vtd_ex">Basado en VTD</string>
+    <string name="list_fb2_xmlparser_duckbill">Tonto &amp; Sucio</string>
+
+    <string name="pref_fontsize_title">Tamaño del tipo de letra</string>
+    <string name="pref_fontsize_summary">Tamaño base del tipo de letra</string>
+
+    <string name="pref_fb2fontpack_title">Tipos de letra FB2</string>
+    <string name="pref_fb2fontpack_summary">Define el paquete de tipos de letra para el renderizado de FB2</string>
+
+    <string name="list_fontsize_tiny">Diminuta</string>
+    <string name="list_fontsize_small">Pequeña</string>
+    <string name="list_fontsize_normal">Normal</string>
+    <string name="list_fontsize_large">Grande</string>
+    <string name="list_fontsize_huge">Enorme</string>
+
+    <string name="pref_fb2hyphen_title">Habilitar separación silábica</string>
+    <string name="pref_fb2hyphen_summary">Activar el soporte experimental para la separación silábica</string>
+
+    <string name="pref_fb2cacheimages_title">Caché de imágenes</string>
+    <string name="pref_fb2cacheimages_summary">Almacenar temporalmente las imágenes de los documentos en disco para reducir el consumo de memoria</string>
 </resources>

--- a/document-viewer/src/main/res/values-es/strings_preferences_ui.xml
+++ b/document-viewer/src/main/res/values-es/strings_preferences_ui.xml
@@ -1,48 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="pref_ui_category">"Interfaz de usuario"</string>
-    <string name="pref_ui_category_summary">"Configuración de la interfaz de usuario"</string>
-    <string name="pref_lang_title">"Idioma"</string>
-    <string name="pref_lang_summary">"Idioma para la interfaz de usuario (necesario reiniciar)"</string>
-    <string name="list_lang_default">"Sistema"</string>
-    <string name="list_lang_en">"Inglés (English)"</string>
-    <string name="list_lang_de">"Alemán (Deutsch)"</string>
-    <string name="list_lang_es">"Español"</string>
-    <string name="list_lang_fr">"Francés (Française)"</string>
-    <string name="list_lang_it">"Italiano (Italiano)"</string>
-    <string name="list_lang_nl">"Holandés (Nederlands)"</string>
-    <string name="list_lang_ru">"Ruso (Русский)"</string>
-    <string name="list_lang_uk">"Ukraniano (Український)"</string>
-    <string name="list_lang_zh">"Chino (中文简体)"</string>
-    <string name="list_lang_iw">"Hebreo (עברית)"</string>
-    <string name="pref_loadrecent_title">"Abrir reciente"</string>
-    <string name="pref_loadrecent_summary">"Al arrancar, abrir automáticamente el último libro"</string>
-    <string name="pref_confirmclose_title">"Confirmar cerrar"</string>
-    <string name="pref_confirmclose_summary">"Confirmar el cierre al presionar Volver"</string>
-    <string name="pref_brightness_title">"Brillo"</string>
-    <string name="pref_brightness_summary">"Establecer la Intensidad general de la imagen (0–100)"</string>
-    <string name="pref_brightnessnightmodeonly_title">"Brillo en modo nocturno"</string>
-    <string name="pref_brightnessnightmodeonly_summary">"Aplicar la configuración de brillo sólo para el modo nocturno"</string>
-    <string name="pref_keepscreenon_title">"No apagar la pantalla"</string>
-    <string name="pref_keepscreenon_summary">"Mantener la pantalla siempre encendida"</string>
-    <string name="pref_fullscreen_title">"Pantalla completa"</string>
-    <string name="pref_fullscreen_summary">"Ocultar la barra de estado."</string>
-    <string name="pref_title_title">"Mostrar título"</string>
-    <string name="pref_title_summary">"Mostrar título. Se necesita reabrir el documento"</string>
-    <string name="pref_pageintitle_title">"Página en el título"</string>
-    <string name="pref_pageintitle_summary">"Mostrar número de página actual en el encabezado"</string>
-    <string name="pref_pagenumbertoastposition_title">"Posición del número de página"</string>
-    <string name="pref_pagenumbertoastposition_summary">"Posición de la tostada con el número de página"</string>
-    <string name="pref_zoomtoastposition_title">"Posición del aumento"</string>
-    <string name="pref_zoomtoastposition_summary">"Posición de la tostada con el aumento aplicado"</string>
-    <string name="list_toastposition_invisible" translatable="true">"Invisible"</string>
-    <string name="list_toastposition_lefttop">"Esquina superior izquierda"</string>
-    <string name="list_toastposition_righttop">"Esquina superior derecha"</string>
-    <string name="list_toastposition_leftbottom">"Esquina inferior izquierda"</string>
-    <string name="list_toastposition_bottom">"Zona inferior de la pantalla"</string>
-    <string name="list_toastposition_righbottom">"Esquina inferior derecha"</string>
-    <string name="pref_showanimicon_title">"Mostrar icono de animación"</string>
-    <string name="pref_showanimicon_summary">"Mostrar animación o icono de desplazamiento si están activados"</string>
+    <string name="pref_ui_category">Interfaz de usuario</string>
+    <string name="pref_ui_category_summary">Configuración de la interfaz de usuario</string>
+
+    <string name="pref_lang_title">Idioma</string>
+    <string name="pref_lang_summary">Idioma para la interfaz de usuario (necesario reiniciar)</string>
+
+    <string name="list_lang_default">Sistema</string>
+    <string name="list_lang_en">Inglés (English)</string>
+    <string name="list_lang_de">Alemán (Deutsch)</string>
+    <string name="list_lang_es">Español</string>
+    <string name="list_lang_fr">Francés (Française)</string>
+    <string name="list_lang_it">Italiano (Italiano)</string>
+    <string name="list_lang_nl">Holandés (Nederlands)</string>
+    <string name="list_lang_ru">Ruso (Русский)</string>
+    <string name="list_lang_uk">Ukraniano (Український)</string>
+    <string name="list_lang_zh">Chino simplificado (中文简体)</string>
+    <string name="list_lang_iw">Hebreo (עברית)</string>
+    <string name="list_lang_ko">Coreano (한국어)</string>
+    <string name="list_lang_eo">Esperanto</string>
+    <string name="list_lang_pl">Polaco (Polski)</string>
+    
+    <string name="pref_loadrecent_title">Abrir reciente</string>
+    <string name="pref_loadrecent_summary">Al arrancar, abrir automáticamente el último libro</string>
+
+    <string name="pref_confirmclose_title">Confirmar cerrar</string>
+    <string name="pref_confirmclose_summary">Confirmar el cierre al presionar Volver</string>
+
+    <string name="pref_brightness_title">Brillo</string>
+    <string name="pref_brightness_summary">Establecer la Intensidad general de la imagen (0&#8211;100)</string>
+
+    <string name="pref_brightnessnightmodeonly_title">Brillo en modo nocturno</string>
+    <string name="pref_brightnessnightmodeonly_summary">Aplicar la configuración de brillo sólo para el modo nocturno</string>
+
+    <string name="pref_keepscreenon_title">Mantener la pantalla encendida</string>
+    <string name="pref_keepscreenon_summary">No apagar la pantalla al leer (no hibernar)</string>
+
+    <string name="pref_fullscreen_title">Pantalla completa</string>
+    <string name="pref_fullscreen_summary">Ocultar la barra de estado</string>
+
+    <string name="pref_title_title">Mostrar título</string>
+    <string name="pref_title_summary">Mostrar título. Se necesita reabrir el documento</string>
+
+    <string name="pref_pageintitle_title">Página en el título</string>
+    <string name="pref_pageintitle_summary">Mostrar número de página actual en el encabezado</string>
+
+    <string name="pref_pagenumbertoastposition_title">Posición del número de página</string>
+    <string name="pref_pagenumbertoastposition_summary">Posición de la tostada con el número de página</string>
+
+    <string name="pref_zoomtoastposition_title">Posición del aumento</string>
+    <string name="pref_zoomtoastposition_summary">Posición de la tostada con el aumento aplicado</string>
+
+    <string name="list_toastposition_invisible" translatable="true">Invisible</string>
+    <string name="list_toastposition_lefttop">Esquina superior izquierda</string>
+    <string name="list_toastposition_righttop">Esquina superior derecha</string>
+    <string name="list_toastposition_leftbottom">Esquina inferior izquierda</string>
+    <string name="list_toastposition_bottom">Zona inferior de la pantalla</string>
+    <string name="list_toastposition_righbottom">Esquina inferior derecha</string>
+
+    <string name="pref_showanimicon_title">Mostrar icono de animación</string>
+    <string name="pref_showanimicon_summary">Mostrar animación o icono de desplazamiento si están activados</string>
 
 </resources>


### PR DESCRIPTION
Update and complete Spanish translation.
I have added \n where appropiate so the layout of the Spanish file matches the English one and then it's easier to see diffs. I've also removed quotes (") where they were not needed, and fixed ending <string> changing them to </string>. I've reviewed the translated strings and added the pending ones.